### PR TITLE
追加: インデントを記述可能なPEGパーサ

### DIFF
--- a/src/main/java/zlk/Main.java
+++ b/src/main/java/zlk/Main.java
@@ -25,6 +25,7 @@ import zlk.idcalc.IcModule;
 import zlk.nameeval.NameEvaluator;
 import zlk.parser.Lexer;
 import zlk.parser.Parser;
+import zlk.parser.Tokenized;
 import zlk.recon.ConstraintExtractor;
 import zlk.recon.FreshFlex;
 import zlk.recon.TypeReconstructor;
@@ -35,21 +36,23 @@ public class Main {
 	public static Class<?> clazz;
 
 	public static void main( String[] args ) throws IOException, ClassNotFoundException, NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchFieldException {
+
 		String name = "HelloMyLang.zlk";
 		String src =
 				"""
 				module HelloMyLang
 
 				type IntList =
-				| Nil
-				| Cons I32 IntList
+				  | Nil
+				  | Cons I32 IntList
 
-				sq a  =
+				sq a =
 				  let
 				    pow b c =
-				      if isZero c
-				      then 1
-				      else mul b (pow b (sub c 1))
+				      if isZero c then
+				        1
+				      else
+				        mul b (pow b (sub c 1))
 				  in
 				    pow a 2
 
@@ -75,8 +78,8 @@ public class Main {
 
 				sum list =
 				  case list of
-				  | Nil -> 0
-				  | Cons hd tl -> add hd (sum tl)
+				    Nil -> 0
+				    Cons hd tl -> add hd (sum tl)
 
 				ans1 =
 				  sq 42
@@ -92,16 +95,21 @@ public class Main {
 		System.out.println(src);
 		System.out.println();
 
+		System.out.println("-- TOKENS --");
+		Tokenized tokens = new Lexer(name, src).lex();
+		tokens.forEach(token -> System.out.println(token));
+		System.out.println();
+
 		System.out.println("-- AST --");
-		Module ast = new Parser(new Lexer(name, src)).parse();
-		ast.pp(System.out);
+		Module ast = Parser.parse(tokens);
+		System.out.println(ast.buildString());
 		System.out.println();
 
 		System.out.println("-- NAME EVAL --");
 		IdList builtinIds = Builtin.functions().stream().map(b -> b.id()).collect(IdList.collector());
 		NameEvaluator ne = new NameEvaluator(ast);
 		IcModule idcalc = ne.eval();
-		idcalc.pp(System.out);
+		System.out.println(idcalc.buildString());
 		System.out.println();
 
 		System.out.println("-- CONSTRAIN EXTRACTION --");
@@ -118,12 +126,6 @@ public class Main {
 		idcalc.types().forEach(union -> union.ctors().forEach(ctor ->
 			types.put(ctor.id(), Type.arrow(ctor.args(), new Type.CtorApp(union.id())))));
 		Builtin.functions().forEach(b -> types.put(b.id(), b.type()));
-
-//		System.out.println("-- TYPE CHECK --");  // TODO remove or support type variables
-//		TypeChecker typeChecker = new TypeChecker(types);
-//		typeChecker.check(idcalc);
-//		System.out.println(types);
-//		System.out.println();
 
 		System.out.println("-- CL CONV --");
 		CcModule clconv = new ClosureConverter(idcalc, types, builtinIds).convert();
@@ -146,7 +148,7 @@ public class Main {
 				}
 			};
 
-		new BytecodeGenerator(clconv, types, Builtin.functions()).compile(fileWriter);
+		new BytecodeGenerator(clconv, types, Builtin.functions(), name).compile(fileWriter);
 
 		System.out.println();
 		System.out.println("-- EXECUTE --");

--- a/src/main/java/zlk/ast/AnType.java
+++ b/src/main/java/zlk/ast/AnType.java
@@ -18,6 +18,15 @@ permits Unit, Var, Type, Arrow {
 	record Type(String ctor, List<AnType> args, Location loc) implements AnType {};
 	record Arrow(AnType arg, AnType ret, Location loc) implements AnType {};
 
+	default AnType updateLoc(Location loc) {
+		return switch(this) {
+		case Unit(Location _) -> new Unit(loc);
+		case Var(String name, Location _) -> new Var(name, loc);
+		case Type(String ctor, List<AnType> args, Location _) -> new Type(ctor, args, loc);
+		case Arrow(AnType arg, AnType ret, Location _) -> new Arrow(arg, ret, loc);
+		};
+	}
+
 	@Override
 	default void mkString(PrettyPrinter pp) {
 		switch(this) {

--- a/src/main/java/zlk/ast/CaseBranch.java
+++ b/src/main/java/zlk/ast/CaseBranch.java
@@ -1,6 +1,7 @@
 package zlk.ast;
 
 import zlk.util.Location;
+import zlk.util.LocationHolder;
 import zlk.util.pp.PrettyPrintable;
 import zlk.util.pp.PrettyPrinter;
 
@@ -8,12 +9,12 @@ public record CaseBranch(
 	Pattern pattern,
 	Exp body,
 	Location loc)
-implements PrettyPrintable {
+implements PrettyPrintable, LocationHolder {
 	@Override
 	public void mkString(PrettyPrinter pp) {
-		pp.append("| ").append(pattern).append(" ->").endl();
+		pp.append(pattern).append(" ->");
 		pp.indent(() -> {
-			pp.append(body);
+			pp.endl().append(body);
 		});
 	}
 }

--- a/src/main/java/zlk/ast/Decl.java
+++ b/src/main/java/zlk/ast/Decl.java
@@ -34,11 +34,11 @@ permits ValDecl, TypeDecl {
 			tyArgs.forEach(arg -> pp.append(arg).append(" "));
 			pp.append("=");
 			if(ctors.size() == 1) {
-				pp.indent(() -> {
-					pp.endl().append(ctors.get(0));
-				});
+				pp.append(" ").append(ctors.get(0));
 			} else {
-				ctors.forEach(ctor -> pp.endl().append("| ").append(ctor));
+				pp.indent(() -> {
+					ctors.forEach(ctor -> pp.endl().append("| ").append(ctor));
+				});
 			}
 		}
 		}

--- a/src/main/java/zlk/ast/Exp.java
+++ b/src/main/java/zlk/ast/Exp.java
@@ -44,6 +44,18 @@ permits Cnst, Var, Lamb, App, If, Let, Case {
 		return exp instanceof Let;
 	}
 
+	default Exp updateLoc(Location loc) {
+		return switch (this) {
+		case Cnst(ConstValue value, Location _) -> new Cnst(value, loc);
+		case Var(String name, Location _) -> new Var(name, loc);
+		case Lamb(List<Pattern> args, Exp body, Location _) -> new Lamb(args, body, loc);
+		case App(List<Exp> exps, Location _) -> new App(exps, loc);
+		case If(Exp cond, Exp thenExp, Exp elseExp, Location _) -> new If(cond, thenExp, elseExp, loc);
+		case Let(List<ValDecl> decls, Exp body, Location _) -> new Let(decls, body, loc);
+		case Case(Exp exp, List<CaseBranch> branches, Location _) -> new Case(exp, branches, loc);
+		};
+	}
+
 	/**
 	 * Appends the string representation of this expression to specified printer.
 	 * It does not terminate the line.
@@ -121,9 +133,9 @@ permits Cnst, Var, Lamb, App, If, Let, Case {
 		}
 		case Case(Exp exp, List<CaseBranch> branches, _) -> {
 			pp.append("case ").append(exp).append(" of");
-			for(CaseBranch branch : branches) {
-				pp.endl().append(branch);
-			}
+			pp.indent(() -> {
+				branches.forEach(branch -> pp.endl().append(branch));
+			});
 		}
 		}
 	}

--- a/src/main/java/zlk/ast/Module.java
+++ b/src/main/java/zlk/ast/Module.java
@@ -7,8 +7,7 @@ import zlk.util.pp.PrettyPrinter;
 
 public record Module(
 		String name,
-		List<Decl> decls,
-		String origin     // ファイル名
+		List<Decl> decls
 ) implements PrettyPrintable {
 
 	@Override

--- a/src/main/java/zlk/ast/Pattern.java
+++ b/src/main/java/zlk/ast/Pattern.java
@@ -14,6 +14,13 @@ permits Var, Ctor {
 	record Var(String name, Location loc) implements Pattern {}
 	record Ctor(String name, List<Pattern> args, Location loc) implements Pattern {}
 
+	default Pattern updateLoc(Location loc) {
+		return switch(this) {
+		case Var(String name, Location _) -> new Var(name, loc);
+		case Ctor(String name, List<Pattern> args, Location _) -> new Ctor(name, args, loc);
+		};
+	}
+
 	@Override
 	default void mkString(PrettyPrinter pp) {
 		switch(this) {

--- a/src/main/java/zlk/bytecodegen/BytecodeGenerator.java
+++ b/src/main/java/zlk/bytecodegen/BytecodeGenerator.java
@@ -48,6 +48,7 @@ import zlk.util.Stack;
 public final class BytecodeGenerator {
 
 	private final CcModule module;
+	private final String origin;
 	private final IdMap<String> classNames;
 	private final IdMap<Type> types;
 	private final IdMap<Builtin> builtins;
@@ -62,11 +63,12 @@ public final class BytecodeGenerator {
 	private MethodVisitor mv;
 	private Stack<Runnable> pendings;
 
-	public BytecodeGenerator(CcModule module, IdMap<Type> types, List<Builtin> builtins) {
+	public BytecodeGenerator(CcModule module, IdMap<Type> types, List<Builtin> builtins, String origin) {
 		this.module = module;
 		this.classNames = new IdMap<>();
 		this.types = types;
 		this.builtins = builtins.stream().collect(IdMap.collector(b -> b.id(), b -> b));
+		this.origin = origin;
 		this.toplevelDescs = new IdMap<>();
 		this.toplevelDecls = new IdMap<>();
 		this.ctors = new IdMap<>();
@@ -125,7 +127,7 @@ public final class BytecodeGenerator {
 				null,
 				"java/lang/Object",
 				null);
-		cw.visitSource(module.origin() + ".zlk", null);
+		cw.visitSource(origin, null);
 		cw.visitNestHost(module.name().replace(".", "/"));
 		cw.visitEnd();
 	}
@@ -139,7 +141,7 @@ public final class BytecodeGenerator {
 				null,
 				"java/lang/Object",
 				new String[] {classNames.get(union.id())});
-		cw.visitSource(module.origin() + ".zlk", null);
+		cw.visitSource(origin, null);
 
 		for(int i = 0; i < ctor.args().size(); i++) {
 			Type type = ctor.args().get(i);
@@ -213,7 +215,7 @@ public final class BytecodeGenerator {
 				"java/lang/Object",
 				null);
 
-		cw.visitSource(module.origin() + ".zlk", null);
+		cw.visitSource(origin, null);
 
 		genConstructor();
 
@@ -228,7 +230,7 @@ public final class BytecodeGenerator {
 
 		cw.visitEnd();
 
-		fileWriter.accept(module.origin(), cw.toByteArray());
+		fileWriter.accept(origin.substring(0, origin.indexOf('.')), cw.toByteArray());
 	}
 
 	private void genConstructor() {

--- a/src/main/java/zlk/clcalc/CcModule.java
+++ b/src/main/java/zlk/clcalc/CcModule.java
@@ -8,8 +8,7 @@ import zlk.util.pp.PrettyPrinter;
 public record CcModule(
 		String name,
 		List<CcTypeDecl> types,
-		List<CcFunDecl> funcs,
-		String origin)
+		List<CcFunDecl> funcs)
 implements PrettyPrintable {
 
 	@Override
@@ -17,7 +16,6 @@ implements PrettyPrintable {
 		pp.append("module:").endl();
 		pp.indent(() -> {
 			pp.append("name: ").append(name).endl();
-			pp.append("origin: ").append(origin).endl();
 			pp.append("decls:");
 			pp.indent(() -> {
 				types.forEach(type -> pp.endl().append(type));

--- a/src/main/java/zlk/clconv/ClosureConverter.java
+++ b/src/main/java/zlk/clconv/ClosureConverter.java
@@ -79,7 +79,7 @@ public final class ClosureConverter {
 					throw new RuntimeException("toplevel must not be closure: "+cls.clsFunc()); }));
 
 		List<CcTypeDecl> types = src.types().stream().map(ty -> convert(ty)).toList();
-		return new CcModule(src.name(), types, toplevels, src.origin());
+		return new CcModule(src.name(), types, toplevels);
 	}
 
 	/**

--- a/src/main/java/zlk/idcalc/IcModule.java
+++ b/src/main/java/zlk/idcalc/IcModule.java
@@ -11,13 +11,11 @@ import zlk.util.pp.PrettyPrinter;
  * @param types 型の定義
  * @param decls トップレベルの関数の定義
  * @param recscc 関数の含まれる強連結成分
- * @param origin ソースコード名
  */
 public record IcModule(
 		String name,
 		List<IcTypeDecl> types,
-		List<IcValDecl> decls,
-		String origin
+		List<IcValDecl> decls
 ) implements PrettyPrintable {
 
 	@Override

--- a/src/main/java/zlk/nameeval/NameEvaluator.java
+++ b/src/main/java/zlk/nameeval/NameEvaluator.java
@@ -147,7 +147,7 @@ public final class NameEvaluator {
 		if(env.scoped.size() != 0) {
 			throw new AssertionError();
 		}
-		return new IcModule(module.name(), icTypes, icDecls, module.origin());
+		return new IcModule(module.name(), icTypes, icDecls);
 	}
 
 	public IcTypeDecl eval(TypeDecl union) {

--- a/src/main/java/zlk/parser/Lexer.java
+++ b/src/main/java/zlk/parser/Lexer.java
@@ -1,198 +1,220 @@
 package zlk.parser;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
+import static zlk.util.ErrorUtils.todo;
 
-import zlk.util.Position;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import zlk.parser.Token.Kind;
+import zlk.util.ChunkedBuffer;
+import zlk.util.IntChunkedBuffer;
 
 /**
- * コードポイントベースの字句解析器．
+ * ソースをトークンのインデントで分離されたブロック構造に変換する
+ * 周りよりインデントの深い場所はENDENTとDEDENTで囲み，同じ高さの改行は
  *
- * コメントも処理する予定
- * @author YuyaAizawa
+ * ソースをトークンに変換する．改行文字は\n, \r\n, \rに対応．
  *
+ * 行ごとに行頭にインデントの増減を表すstromaトークン，その後に行中のparenchymaトークンを列にする．
+ * 行頭はインデントが増えた場合INDENT，減った場合DEDENTをレベルの増減と同じ数だけ入れる．
+ * 増減が無ければNEWLINE，1つが対応する．
+ * parenchymaが1つもない行は飛ばす．
  */
-public class Lexer {
+public final class Lexer {
 	private final String fileName;
-	private final Reader reader;
-	int current;
-	int buffer;
-	int count;
-
-	int currentLine; // 行数
-	int currentColumn; // コードポイント数
-
-	int[] wordArray = new int[256];
-
-	private static final char CR = '\r';
-	private static final char LF = '\n';
-
-	public Lexer(String fileName) throws IOException {
-		this.fileName = fileName;
-		this.reader = new BufferedReader(new FileReader(fileName, StandardCharsets.UTF_8));
-		next();
-		next();
-		currentColumn = 1;
-		currentLine = 1;
-	}
+	private final String src;
+	int idx;  // 現在の読取り位置
+	int currentLevel;  // 現在のインデントレベル
+	int lineStartIdx;  // 現在の行の先頭位置
+	IndentStyle indentStyle;
+	IntChunkedBuffer lineStartIndexes;
+	ChunkedBuffer<Token> result;
 
 	public Lexer(String fileName, String src) {
 		this.fileName = fileName;
-		this.reader = new StringReader(src);
-		next();
-		next();
-		currentColumn = 1;
-		currentLine = 1;
+		this.src = src;
 	}
 
-	public String getFileName() {
-		return fileName;
+	public Lexer(String fileName) throws IOException {
+		this(fileName, Files.readString(Paths.get(fileName)));
 	}
 
-	public Token nextToken() {
-		skipIgnoringChars();
+	public Tokenized lex() {
+		idx = 0;
+		currentLevel = 0;
+		indentStyle = IndentStyle.UNKNOWN;
+		lineStartIndexes = new IntChunkedBuffer();
+		result = new ChunkedBuffer<>(Token[]::new);
+		Source info = new Source(fileName, src);
+		int srcLength = src.length();
 
-		Position pos = new Position(currentLine, currentColumn);
-		Token token = switch(current) {
+		READ_LOOP:
+		while(idx < srcLength) {
+			// 行のはじめにここに戻る
+			lineStartIdx = idx;
+			lineStartIndexes.add(lineStartIdx);
 
-		case '|' -> new Token(Token.Kind.BAR, pos);
-		case LF  -> new Token(Token.Kind.BR, pos);
-		case ':' -> new Token(Token.Kind.COLON, pos);
-		case '=' -> new Token(Token.Kind.EQUAL, pos);
-		case '\\' -> new Token(Token.Kind.LAMBDA, pos);
-		case '(' -> ifNext(')')
-				? new Token(Token.Kind.UNIT, pos)
-				: new Token(Token.Kind.LPAREN, pos);
-		case ')' -> new Token(Token.Kind.RPAREN, pos);
+			// 行頭の空白からインデントを計算
+			indentStyle = indentStyle.initIndentStyleIfNeeded(src, idx);
+			int level = indentStyle.count(src, idx);
+			idx += level * indentStyle.value.length();
 
-		case '-' -> ifNext('>')
-				? new Token(Token.Kind.ARROW, pos)
-				: new Token(Token.Kind.ILL, '-' + codepointToString(current), pos);
-
-		case  -1 -> new Token(Token.Kind.EOF, pos);
-
-		default -> {
-			if(isLower(current)) {
-				String id = readWord();
-				Token.Kind kind = Token.Kind.lookupKeywordType(id);
-				if(kind == null) {
-					yield new Token(Token.Kind.LCID, id, pos);
-				} else {
-					yield new Token(kind, pos);
+			// 行末まで空なら次の行へ コメントを処理するならたぶんココ
+			char c = src.charAt(idx);
+			if(c == '\r') {
+				idx++;
+				if(idx < srcLength && src.charAt(idx) == '\n') {
+					idx++;
 				}
-			} else if(isUpper(current)) {
-				yield new Token(Token.Kind.UCID, readWord(), pos);
-			} else if(isDigit(current)) {
-				yield new Token(Token.Kind.DIGITS, readWord(), pos);
+				continue READ_LOOP;
+			} else if(c == '\n') {
+				idx++;
+				continue READ_LOOP;
+			} else if(isPrintableAscii(c)) {
+				// 中身のある行だけ後続の処理へ
 			} else {
-				yield new Token(Token.Kind.ILL, new String(new int[] {current}, 0, 1), pos);
+				todo("'"+c+"' is unsupported"); // TODO: スペース奇数のときの対応とか
 			}
-		}};
-		next();
-		return token;
+
+			// インデントトークンを追加
+			int levelDiff = currentLevel - level;
+			if(levelDiff < 0) {
+				for(int i = levelDiff; i < 0; i++) {
+					result.add(new Token(info, Token.Kind.ENDENT, lineStartIdx, idx));
+				}
+			}
+			if(levelDiff > 0) {
+				for(int i = levelDiff; i > 0; i--) {
+					result.add(new Token(info, Token.Kind.DEDENT, lineStartIdx, idx));
+				}
+			}
+			result.add(new Token(info, Token.Kind.SAMENT, lineStartIdx, idx));
+			currentLevel = level;
+
+			// 行内トークンを追加
+			while(idx < srcLength) {
+				c = src.charAt(idx);
+
+				// 改行なら行内処理を終える
+				if(c == '\r') {
+					idx++;
+					if(idx < srcLength && src.charAt(idx) == '\n') {
+						idx++;
+					}
+					break;
+				} else if(c == '\n') {
+					idx++;
+					break;
+				}
+
+				// トークン開始
+				int start = idx;
+				if(isUpper(c)) {  // UCID
+					while(++idx < srcLength && isIdentifierPart(src.charAt(idx)));
+					result.add(new Token(info, Kind.UCID, start, idx));
+				} else if(isLower(c)) {  // LCID or keyword
+					while(++idx < srcLength && isIdentifierPart(src.charAt(idx)));
+					Kind k = Token.Kind.lookupKeyword(src.substring(start, idx));
+					result.add(new Token(info, k == null ? Kind.LCID : k, start, idx));
+				} else if(isPunctuator(c)) {  // punctuator
+					Kind k = Token.Kind.lookupPunctuator(src, start);
+					if(k != null) {
+						idx += k.str().length();
+						result.add(new Token(info, k, start, idx));
+					} else {
+						while(++idx < srcLength && isPunctuator(src.charAt(idx)));
+						result.add(new Token(info, Kind.ILL, start, idx));
+					}
+				} else if(isDigit(c)) {  // DIGIT
+					while(++idx < srcLength && isDigit(src.charAt(idx)));
+					result.add(new Token(info, Kind.DIGITS, start, idx));
+				} else {
+					todo("unsupported token start char'"+c+"'@"+idx);
+				}
+				if(idx < srcLength && src.charAt(idx) == ' ') {  // スペースがあれば1つまで飛ばす
+					idx++;
+				}
+			}
+			// TODO: 行末の処理 なんかあったっけ
+		}
+		// 閉じていないブロックを閉じる
+		for (int i = 0; i < currentLevel; i++) {
+			result.add(new Token(info, Token.Kind.DEDENT, idx, idx));
+		}
+		// 共有情報に改行位置を登録
+		info.lineStartIndexes = lineStartIndexes.toArray();
+
+		return new Tokenized(result.toArray());
 	}
 
-	private void next() {
-		if(current == LF) {
-			currentLine++;
-			currentColumn = 0;
-		}
-		current = buffer;
-		currentColumn++;
+	private static boolean isPrintableAscii(char c) {
+		return '!' <= c && c <= '~';
+	}
+	private static boolean isUpper(char c) {
+		return 'A' <= c && c <= 'Z';
+	}
+	private static boolean isLower(char c) {
+		return 'a' <= c && c <= 'z';
+	}
+	private static boolean isDigit(char c) {
+		return '0' <= c && c <= '9';
+	}
+	private static boolean isIdentifierPart(char c) {
+		return isUpper(c) || isLower(c) || isDigit(c) || c == '_';
+	}
+	private static boolean isPunctuator(char c) {
+		return '!' <= c && c <= '/'
+				|| ':' <= c && c <= '@'
+				|| '[' <= c && c <= '`'
+				|| '{' <= c && c <= '~';
+	}
+}
 
-		int data = uncheckRead();
+enum IndentStyle {
+	UNKNOWN(""),
+	TAB("\t"),
+	SPACE2("  "),
+	SPACE4("    ");
 
-		if(Character.isHighSurrogate((char)data)) {
-			char high = (char) data;
-			int tmp = uncheckRead();
-			if(tmp == -1) {
-				throw new RuntimeException("EOF while surrogate pair.");
-			}
-			char low = (char) tmp;
-			if(Character.isLowSurrogate(low)) {
-				buffer = Character.codePointAt(new char[] {high, low}, 0);
-				count++;
-				return;
-			}
-		}
-
-		buffer = data;
-		count++;
+	String value;
+	private IndentStyle(String value) {
+		this.value = value;
 	}
 
-	private int uncheckRead() {
-		try {
-			return reader.read();
-		} catch (IOException e) {
-			throw new UncheckedIOException(e);
+	IndentStyle initIndentStyleIfNeeded(String src, int i) {
+		if(this != UNKNOWN) {
+			return this;
 		}
+		if(src.startsWith(TAB.value, i)) {
+			return TAB;
+		} else if(src.startsWith(SPACE4.value, i)) {
+			return SPACE4;
+		} else if(src.startsWith(SPACE2.value, i)) {
+			return SPACE2;
+		}
+		return UNKNOWN;
 	}
 
 	/**
-	 * 次の文字が指定したものなら読み進めtrueを返し，そうでなければ読み進めずfalseを返す
-	 * @param target
-	 * @return
+	 * 文字列の指定された位置から，このインデントでのレベルを返す．
+	 * @param src
+	 * @param offset
+	 * @return インデントレベル
 	 */
-	private boolean ifNext(int target) {
-		if(buffer == target) {
-			next();
-			return true;
-		} else {
-			return false;
+	int count(String src, int offset) {
+		char prefix = src.charAt(offset);
+		if(prefix != ' ' && prefix != '\t') {
+			return 0;
 		}
-	}
-
-	private void skipIgnoringChars() {
-		while (isIgnoringChar(current)) {
-			next();
+		if(this == UNKNOWN) {
+			throw new IllegalStateException("UNKOWN indent cannot count.");
 		}
-	}
-
-	private String readWord() {
-		try {
-			int idx = 0;
-			while(isLetterOrDigit(buffer)) {
-				wordArray[idx++] = current;
-				next();
-			}
-			wordArray[idx++] = current;
-
-			return new String(wordArray, 0, idx).intern();
-		} catch(ArrayIndexOutOfBoundsException e) {
-			throw new RuntimeException("too long word.");
+		int c = 0;
+		while(src.startsWith(value, offset)) {
+			c++;
+			offset += value.length();
 		}
-	}
-
-	private static boolean isIgnoringChar(int cp) {
-		return cp == '\s' || cp == '\t' || cp == CR;
-	}
-
-	private static boolean isLetterOrDigit(int cp) {
-		return
-				isLower(cp) ||
-				isUpper(cp) ||
-				isDigit(cp) ||
-				cp == '_';
-	}
-
-	private static boolean isLower(int cp) {
-		return 'a' <= cp && cp <= 'z';
-	}
-
-	private static boolean isUpper(int cp) {
-		return 'A' <= cp && cp <= 'Z';
-	}
-
-	private static boolean isDigit(int cp) {
-		return '0' <= cp && cp <= '9';
-	}
-
-	private static String codepointToString(int codepoint) {
-		return new String(new int[] {codepoint}, 0, 1);
+		return c;
 	}
 }

--- a/src/main/java/zlk/parser/Parser.java
+++ b/src/main/java/zlk/parser/Parser.java
@@ -1,30 +1,16 @@
 package zlk.parser;
 
-import static zlk.parser.Token.Kind.ARROW;
-import static zlk.parser.Token.Kind.BAR;
-import static zlk.parser.Token.Kind.BR;
-import static zlk.parser.Token.Kind.CASE;
-import static zlk.parser.Token.Kind.COLON;
-import static zlk.parser.Token.Kind.DIGITS;
-import static zlk.parser.Token.Kind.ELSE;
-import static zlk.parser.Token.Kind.EOF;
-import static zlk.parser.Token.Kind.EQUAL;
-import static zlk.parser.Token.Kind.IF;
-import static zlk.parser.Token.Kind.IN;
-import static zlk.parser.Token.Kind.LCID;
-import static zlk.parser.Token.Kind.LET;
-import static zlk.parser.Token.Kind.LPAREN;
-import static zlk.parser.Token.Kind.MODULE;
-import static zlk.parser.Token.Kind.OF;
-import static zlk.parser.Token.Kind.RPAREN;
-import static zlk.parser.Token.Kind.THEN;
-import static zlk.parser.Token.Kind.TYPE;
-import static zlk.parser.Token.Kind.UCID;
+import static zlk.parser.Peg.choice;
+import static zlk.parser.Peg.kind;
+import static zlk.parser.Peg.lazy;
+import static zlk.parser.Peg.optional;
+import static zlk.parser.Peg.plus;
+import static zlk.parser.Peg.sequence;
+import static zlk.parser.Peg.star;
 import static zlk.util.ErrorUtils.todo;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,528 +19,409 @@ import zlk.ast.CaseBranch;
 import zlk.ast.Constructor;
 import zlk.ast.Decl;
 import zlk.ast.Decl.TypeDecl;
-import zlk.ast.Decl.ValDecl;
 import zlk.ast.Exp;
-import zlk.ast.Exp.App;
-import zlk.ast.Exp.Case;
-import zlk.ast.Exp.Cnst;
-import zlk.ast.Exp.If;
-import zlk.ast.Exp.Lamb;
-import zlk.ast.Exp.Let;
-import zlk.ast.Exp.Var;
 import zlk.ast.Module;
 import zlk.ast.Pattern;
-import zlk.common.ConstValue;
 import zlk.parser.Token.Kind;
 import zlk.util.Location;
-import zlk.util.Position;
+import zlk.util.LocationHolder;
+
 
 /**
- * 構文解析器.
+ * 構文解析器．
+ *
  * <h2>文法</h2>
+ * ※空白文字の記述を決めかねているためその点正確でない
  * <pre>{@code
  * <h3>コンパイル単位</h3>
- * <module>   ::= module <ucid> <br>+ (<topDecl> <br>+)*
+ * <module>     ::= module <ucid> <topDecl>*
  *
- * <topDecl>  ::= <typeDecl>
- *              | <valDecl>
+ * <topDecl>    ::= <tyDecl>
+ *                | <valDecl>
  *
  * <h3>宣言</h3>
- * <typeDecl> ::= type <ucid> <aType>* = <ctor> (| <ctor>)*
+ * <tyDecl>     ::= type <ctorHead> <tyVar>* = |? <ctorImpl> (| <ctorImpl>)*
  *
- * <ctor>     ::= <ucid> <tyConArg>*
+ * <ctorImpl>   ::= <ctorHead> <ctorArg>*
  *
- * <valDecl>  ::= (<lcid> : <type> <br>)? <lcid> <pattern>* = <br>? <exp>
+ * <valDecl>    ::= <tyAnno>? <lcid> <pattern>* = <exp>
  *
- * <h3>式
- * <exp>      ::= <aExp>+
- *              | \ <pattern>+ <br>? -> <exp>
- *              | let <funDecl>+ in <exp>
- *              | if <exp> then <exp> else <exp>
- *              | case <exp> of (| <pattern> -> <exp>)+
+ * <tyAnno>     ::= <lcid> : <type>
  *
- * <aExp>     ::= ( <exp> )
- *              | <aLiteral>
- *              | <lcid>
+ * <h3>式</h3>
+ * <exp>        ::= <aExp>+
+ *                | \ <pattern>+ -> <exp>
+ *                | let <valDecl>+ in <exp>
+ *                | if <exp> then <exp> else <exp>
+ *                | case <exp> of (<pattern> -> <exp>)+
+ *
+ * <aExp>       ::= ( <exp> )
+ *                | <aLiteral>
+ *                | <ctorHead>
+ *                | <lcid>
  *
  * <h3>パターン</h3>
- * <pattern>  ::= <ucid> <aPattern>*
- *              | <aPattern>
+ * <pattern>    ::= <ctorHead> <aPattern>*
+ *                | <aPattern>
  *
- * <aPattern> ::= ( <pattern> )
- *              | <lcid>
+ * <aPattern>   ::= ( <pattern> )
+ *                | <lcid>
  *
  * <h3>型注釈</h3>
- * <type>     ::= <funTyArg> (-> <type>)?
+ * <type>       ::= <funTyArg> (-> <funTyArg>)*
  *
- * <funTyArg> ::= ()
- *              | <lcid>
- *              | <ucid> <tyConArg>*
- *              | ( <type> )
+ * <funTyArg>   ::= ()
+ *                | <tyVar>
+ *                | <ctorAnno>
+ *                | ( <type> )
  *
- * <tyConArg> ::= ()
- *              | <lcid>
- *              | <ucid>
- *              | ( <type> )
+ * <ctorAnno>   ::= <ctorHead> <ctorArg>*
+ *
+ * <ctorArg>    ::= ()
+ *                | <tyVar>
+ *                | <ctorHead>
+ *                | ( <type> )
+ *
+ * <ctorHead>   ::= <ucid>
+ *
+ * <tyVar>      ::= <lcid>
  * }</pre>
  */
-public class Parser {
-
-	private static final EnumSet<Kind> cancelBr = EnumSet.of(
-			BAR,
-			THEN,
-			ELSE,
-			ARROW);
-
-	private final Lexer lexer;
-
-	private Token current;
-	private Token next;
-
-	private Position end;
-
-	public Parser(Lexer lexer) {
-		this.lexer = lexer;
-		this.current = lexer.nextToken();
-		this.next = lexer.nextToken();
-	}
-
-	public Parser(String fileName) throws IOException {
-		this(new Lexer(fileName));
-	}
-
-	public Module parse() {
-		return parseModule(lexer.getFileName().split("\\.")[0]);
-	}
-
-	public Module parseModule(String fileName) {
-		consume(MODULE);
-
-		String name = parse(UCID);
-
-		consume(BR);
-		while(maybeConsume(BR));
-
-		List<Decl> topDecls = new ArrayList<>();
-		while(current.kind() != EOF) {
-			if(current.kind() == TYPE) {
-				topDecls.add(parseTypeDecl());
-			} else {
-				topDecls.add(parseValDecl());
-			}
-			consume(BR);
-			while(maybeConsume(BR));
-		}
-
-		return new Module(name, topDecls, fileName);
-	}
-
-	public TypeDecl parseTypeDecl() {
-		Position start = current.pos();
-
-		consume(TYPE);
-
-		String name = parse(UCID);
-
-		List<AnType.Var> tyArgs = new ArrayList<>();
-		AnType.Var tyArg;
-		while((tyArg = maybeParseTyVar()) != null) {
-			tyArgs.add(tyArg);
-		}
-
-		consume(EQUAL);
-
-		maybeConsume(BAR);
-
-		List<Constructor> ctors = new ArrayList<>();
-		ctors.add(parseConstructor());
-		while(current.kind() == BAR) {
-			consume(BAR);
-			ctors.add(parseConstructor());
-		}
-
-		return new TypeDecl(name, tyArgs, ctors, location(start, end));
-	}
-
-	private Constructor parseConstructor() {
-		Position start = current.pos();
-
-		String name = parse(UCID);
-
-		List<AnType> args = new ArrayList<>();
-		AnType arg;
-		while((arg = maybeParseTyConArg()) != null) {
-			args.add(arg);
-		}
-
-		return new Constructor(name, args, location(start, end));
-	}
-
-	public ValDecl parseValDecl() {
-		Position start = current.pos();
-
-		String name = parse(LCID);
-
-		Optional<AnType> anno;
-		if(maybeConsume(COLON)) {
-			anno = Optional.of(parseType());
-
-			consume(BR);
-
-			if(!parse(LCID).equals(name)) {
-				throw new RuntimeException(
-						current.pos() + " declatarion must have the same name with annotation");
-			}
-		} else {
-			anno = Optional.empty();
-		}
-
-		List<Pattern> args = new ArrayList<>();
-		while(current.kind() != EQUAL) {
-			args.add(parsePattern());
-		}
-
-		consume(EQUAL);
-
-		maybeConsume(BR);
-
-		Exp body = parseExp();
-
-		return new ValDecl(name, anno, args, body, location(start, end));
-	}
-
-	public Exp parseExp() {
-		Position start = current.pos();
-		if(aExpStartToken(current)) {
-			Exp first = parseAExp();
-
-			if(aExpStartToken(current)) {
-				List<Exp> exps = new ArrayList<>();
-				exps.add(first);
-
-				while(aExpStartToken(current)) {
-					exps.add(parseAExp());
-				}
-				return new App(exps, location(start, end));
-			} else {
-				return first;
-			}
-		}
-
-		return switch(current.kind()) {
-		case LAMBDA -> parseLambdaExp();
-		case LET -> parseLetExp();
-		case IF -> parseIfExp();
-		case CASE -> parseCaseExp();
-		default -> throw new RuntimeException("not exp");
-		};
-	}
-
-	private static boolean aExpStartToken(Token token) {
-		switch (token.kind()) {
-		case LCID:
-		case UCID:
-		case DIGITS:
-		case TRUE:
-		case FALSE:
-		case LPAREN:
-			return true;
-		default:
-			return false;
-		}
-	}
-
-	private Exp parseAExp() {
-		Position start = current.pos();
-		return switch(current.kind()) {
-
-		case LPAREN -> parseParenExp();
-
-		case TRUE -> {
-			nextToken();
-			yield new Cnst(ConstValue.TRUE, location(start, end));
-		}
-
-		case FALSE -> {
-			nextToken();
-			yield new Cnst(ConstValue.FALSE, location(start, end));
-		}
-
-		case DIGITS -> new Cnst(Integer.valueOf(parse(DIGITS)), location(start, end));
-
-		case LCID -> new Var(parse(LCID), location(start, end));
-		case UCID -> new Var(parse(UCID), location(start, end));
-
-		default -> throw new RuntimeException("not a exp");
-		};
-	}
-
-	private Exp parseLambdaExp() {
-		Position start = current.pos();
-
-		List<Pattern> args = new ArrayList<>();
-		do {
-			args.add(parsePattern());
-		} while(current.kind() != ARROW);
-
-		consume(ARROW);
-
-		Exp body = parseExp();
-
-		return new Lamb(args, body, location(start, end));
-	}
-
-	private Exp parseLetExp() {
-		Position start = current.pos();
-
-		consume(LET);
-
-		List<ValDecl> declList = new ArrayList<>();
-		if(maybeConsume(BR)) {
-			do {
-				declList.add(parseValDecl());
-
-				consume(BR);
-			} while(current.kind() != IN);
-
-			consume(IN);
-
-			consume(BR);
-		} else {
-			declList.add(parseValDecl());
-
-			consume(IN);
-
-			maybeConsume(BR);
-		}
-
-		Exp body = parseExp();
-
-		return new Let(declList, body, location(start, end));
-	}
-
-	private Exp parseIfExp() {
-		Position start = current.pos();
-		consume(IF);
-
-		maybeConsume(BR);
-
-		Exp c = parseExp();
-
-		consume(THEN);
-
-		maybeConsume(BR);
-
-		Exp t = parseExp();
-
-		consume(ELSE);
-
-		maybeConsume(BR);
-
-		Exp e = parseExp();
-
-		return new If(c, t, e, location(start, end));
-	}
-
-	private Exp parseCaseExp() {
-		Position start = current.pos();
-
-		consume(CASE);
-
-		Exp exp = parseExp();
-
-		consume(OF);
-
-		List<CaseBranch> caseBranches = new ArrayList<>();
-		do {
-			caseBranches.add(parseCaseBranch());
-		} while(current.kind() == BAR);
-
-		return new Case(exp, caseBranches, location(start, end));
-	}
-
-	private CaseBranch parseCaseBranch() {
-		Position start = current.pos();
-
-		consume(BAR);
-
-		Pattern pattern = parsePattern();
-
-		consume(ARROW);
-
-		maybeConsume(BR);
-
-		Exp body = parseExp();
-
-		return new CaseBranch(pattern, body, location(start, end));
-	}
-
-	private Pattern parsePattern() {
-		Position start = current.pos();
-
-		if(current.kind() == UCID) {
-			String name = parse(UCID);
-
-			List<Pattern> args = new ArrayList<>();
-			while(current.kind() != ARROW) {
-				args.add(parseAPattern());
-			}
-			return new Pattern.Ctor(name, args, location(start, end));
-		}
-
-		return parseAPattern();
-	}
-
-	private Pattern parseAPattern() {
-		Position start = current.pos();
-		Pattern result;
-
-		if(current.kind() == LPAREN) {
-			consume(LPAREN);
-
-			result = parsePattern();
-
-			consume(RPAREN);
-		} else {
-			result = new Pattern.Var(parse(LCID), location(start, end));
+public final class Parser {
+
+	public static Module parse(Tokenized src) {
+		Module result = module.parse(src);
+		if(result == null) {
+			todo("error");
 		}
 		return result;
 	}
 
-	private Exp parseParenExp() {
-		consume(LPAREN);
-
-		Exp exp = parseExp();
-
-		consume(RPAREN);
-
-		return exp;
+	public static Module parse(String fileName, String src) {
+		return parse(new Lexer(fileName, src).lex());
 	}
 
-	public AnType parseType() {
-		Position start = current.pos();
-
-		AnType ty = parseFunTyArg();
-
-		if(maybeConsume(ARROW)) {
-			return new AnType.Arrow(ty, parseType(), location(start, end));
-		}
-		return ty;
+	public static Module parse(String fileName) throws IOException {
+		return parse(new Lexer(fileName).lex());
 	}
 
-	private AnType parseFunTyArg() {
-		return switch(current.kind()) {
-		case UNIT -> parseUnit();
-		case LCID -> parseTyVar();
-		case UCID -> parseTyConApp();
-		case LPAREN -> parseParenType();
-		default -> todo("syntax error");
-		};
+	public static AnType parseTypeForTest(String src) {
+		Tokenized tokens = new Lexer("TypeForTest.zlk", src).lex();
+		SAMENT.parse(tokens);
+		return type.parse(tokens);
 	}
 
-	private AnType parseTyConApp() {
-		Position start = current.pos();
-		String tyCon = parse(UCID);
+	// static fieldを上から初期化する都合で補助関数が最上部，全体のパーサは最下部にある
 
-		List<AnType> args = new ArrayList<>();
-		AnType tyConArg;
-		while((tyConArg = maybeParseTyConArg()) != null) {
-			args.add(tyConArg);
-		}
+	// TODO: blockを利用してエラー復帰機構
+	static <T> Peg<T> block(Peg<T> p) {
+		return sequence(ENDENT, SAMENT, p, DEDENT, (_, _, r, _) -> r);
+	}
 
-		return new AnType.Type(tyCon, args, location(start, end));
+	static <T> Peg<T> mayBlock(Peg<T> p) {
+		return choice(block(p), p);
 	}
 
 	/**
-	 * 失敗時にnullを返すので注意
+	 * 複数要素からなるブロックのパーサを返す
+	 * @param <T>
+	 * @param head 最初の要素のパーサ（頭カンマなしとかそういう用途）
+	 * @param head 以降の要素のパーサ
 	 * @return
 	 */
-	private AnType maybeParseTyConArg() {
-		Position start = current.pos();
-		return switch(current.kind()) {
-		case UNIT -> parseUnit();
-		case LCID -> parseTyVar();
-		case UCID -> new AnType.Type(parse(UCID), List.of(), location(start, end));
-		case LPAREN -> parseParenType();
-		default -> null;
-		};
+	static <T> Peg<List<T>> blockPlus(Peg<T> head, Peg<T> tail) {
+		Peg<T> samentHead = sequence(SAMENT, head, (_, r) -> r);
+		Peg<T> samentTail = sequence(SAMENT, tail, (_, r) -> r);
+		return sequence(ENDENT, samentHead, star(samentTail), DEDENT, (_, hd, tl, _) -> prepend(hd, tl));
+	}
+	static <T> Peg<List<T>> blockPlus(Peg<T> head) {
+		return blockPlus(head, head);
 	}
 
-	private AnType parseParenType() {
-		consume(LPAREN);
+	static <T> Peg<List<T>> join(Peg<T> p, Peg<?> delimiter) {
+		return sequence(
+				p, star(sequence(delimiter, p, (_, v) -> v)),
+				(hd, tl) -> prepend(hd, tl));
+	}
 
-		AnType type = parseType();
+	static <T> List<T> prepend(T head, List<? extends T> tail) {
+		List<T> out = new ArrayList<>(tail.size() + 1);
+		out.add(head);
+		out.addAll(tail);
+		return out;
+	}
 
-		consume(RPAREN);
+	// Locationの範囲を求める
+	static Location locRange(LocationHolder from, LocationHolder to) {
+		return Location.range(from.loc(), to.loc());
+	}
+	static Location locRange(LocationHolder from, List<? extends LocationHolder> to) {
+		if(to.isEmpty()) {
+			return from.loc();
+		}
+		return Location.range(from.loc(), to.getLast().loc());
+	}
+	static Location locRange(List<? extends LocationHolder> from, LocationHolder to) {
+		if(from.isEmpty()) {
+			return to.loc();
+		}
+		return Location.range(from.getFirst().loc(), to.loc());
+	}
+	static Location locRange(List<? extends LocationHolder> from, List<? extends LocationHolder> to) {
+		if(from.isEmpty()) {
+			if(to.isEmpty()) {
+				return Location.noLocation();
+			}
+			return Location.range(to.getFirst().loc(), to.getLast().loc());
+		}
+		return locRange(from.getFirst(), to);
+	}
 
+	static final Peg<Token> ENDENT = kind(Kind.ENDENT);
+	static final Peg<Token> DEDENT = kind(Kind.DEDENT);
+	static final Peg<Token> SAMENT = kind(Kind.SAMENT);
+
+	static final Peg<Token> ARROW = kind(Kind.ARROW);
+	static final Peg<Token> BAR = kind(Kind.BAR);
+	static final Peg<Token> CASE = kind(Kind.CASE);
+	static final Peg<Token> COLON = kind(Kind.COLON);
+	static final Peg<Token> ELSE = kind(Kind.ELSE);
+	static final Peg<Token> EQUAL = kind(Kind.EQUAL);
+	static final Peg<Token> IF = kind(Kind.IF);
+	static final Peg<Token> IN = kind(Kind.IN);
+	static final Peg<Token> LAMBDA = kind(Kind.LAMBDA);
+	static final Peg<Token> LET = kind(Kind.LET);
+	static final Peg<Token> LPAREN = kind(Kind.LPAREN);
+	static final Peg<Token> MODULE = kind(Kind.MODULE);
+	static final Peg<Token> OF = kind(Kind.OF);
+	static final Peg<Token> RPAREN = kind(Kind.RPAREN);
+	static final Peg<Token> THEN = kind(Kind.THEN);
+	static final Peg<Token> TYPE = kind(Kind.TYPE);
+
+	static final Peg<Token> FALSE = kind(Kind.FALSE);
+	static final Peg<Token> TRUE = kind(Kind.TRUE);
+
+	static final Peg<Token> UCID = kind(Kind.UCID);
+	static final Peg<Token> LCID = kind(Kind.LCID);
+	static final Peg<Token> DIGITS = kind(Kind.DIGITS);
+
+	/* 型注釈
+	 * <tyVar>      ::= <lcid>
+	 *
+	 * <ctorHead>   ::= <ucid>
+	 *
+	 * <parenType>  ::= ( <type> )
+	 *
+	 * <ctorArg>    ::= ()
+	 *                | <tyVar>
+	 *                | <ctorHead>
+	 *                | <parenType>
+	 *
+	 * <ctorAnno>   ::= <ctorHead> <ctorArg>*
+	 *
+	 * <funTyArg>   ::= ()
+	 *                | <tyVar>
+	 *                | <ctorAnno>
+	 *                | <parenType>
+	 *
+	 * <type>       ::= <funTyArg> (-> <funTyArg>)*
+	 */
+	static final Peg<AnType.Var> tyVar =
+			LCID.map(token -> new AnType.Var(token.str(), token.loc()));
+
+	static final Peg<Token> ctorHead = UCID;
+
+	static final Peg<AnType> parenType = sequence(
+			LPAREN, lazy(() -> type()), RPAREN,
+			(s, ty, e) -> ty.updateLoc(locRange(s, e)));
+
+	static final Peg<AnType> ctorArg = choice(  // コンストラクタの引数部分に来れる要素
+			tyVar,
+			ctorHead.map(t -> new AnType.Type(t.str(), List.of(), t.loc())),
+			parenType);
+
+	static final Peg<AnType.Type> ctorAnno = sequence(
+			ctorHead, star(ctorArg),
+			(h, args) -> new AnType.Type(h.str(), args, locRange(h, args)));
+
+	static final Peg<AnType> funTyArg = choice(  // 関数型の引数部分に来れる要素
+			tyVar,
+			ctorAnno,
+			parenType);
+
+	static final Peg<AnType> type = sequence(funTyArg, star(sequence(ARROW, funTyArg, (_, t) -> t)),
+			(hd, tl) -> {
+				if(tl.size() == 0) {
+					return hd;
+				}
+				AnType result = tl.removeLast();
+				for(AnType ty : tl.reversed()) {
+					result = new AnType.Arrow(ty, result, locRange(ty, result));
+				}
+				return new AnType.Arrow(hd, result, locRange(hd, result));
+			});
+
+	private static Peg<AnType> type() {
 		return type;
 	}
 
-	private AnType parseUnit() {
-		Position start = current.pos();
-		consume(Kind.UNIT);
-		return new AnType.Unit(location(start, end));
+	/* パターン
+	 * <aPattern>   ::= <lcid>
+	 *                | ( <pattern> )
+	 *
+	 * <pattern>    ::= <ctorHead> <aPattern>*
+	 *                | <aPattern>
+	 */
+	static final Peg<Pattern> aPattern = choice(
+			LCID.map(t -> new Pattern.Var(t.str(), t.loc())),
+			sequence(LPAREN, lazy(() -> pattern()), RPAREN,
+					(s, pat, e) -> pat.updateLoc(locRange(s, e))));
+
+	static final Peg<Pattern> pattern = choice(
+			sequence(ctorHead, star(aPattern),
+					(h, args) -> new Pattern.Ctor(h.str(), args, locRange(h, args))),
+			aPattern);
+
+	private static Peg<Pattern> pattern() {
+		return pattern;
 	}
 
-	private AnType.Var maybeParseTyVar() {
-		if(current.kind() != LCID) {
-			return null;
-		}
-		return parseTyVar();
+	/* 式
+	 * <literal>    ::= <digits>
+	 *                | True
+	 *                | False
+	 *
+	 * <aExp>       ::= <literal>
+	 *                | <lcid>
+	 *                | <ctorHead>
+	 *                | ( <exp> )
+	 *
+	 * <appExp>     ::= <aExp>+
+	 *
+	 * <lambdaExp>  ::= \ <pattern>+ -> <exp>
+	 *
+	 * <letExp>     ::= let <funDecl>+ in <exp>
+	 *
+	 * <ifExp>      ::= if <exp> then <exp> else <exp>
+	 *
+	 * <caseExp>    ::= case <exp> of (<pattern> -> <exp>)+
+	 *
+	 * <exp>        ::= <appExp>
+	 *                | <lambdaExp>
+	 *                | <letExp>
+	 *                | <ifExp>
+	 *                | <caseExp>
+	 */
+	static final Peg<Exp> exp_ = lazy(() -> exp());
+
+	static final Peg<Exp.Cnst> literal = choice(
+			DIGITS.map(t -> new Exp.Cnst(Integer.parseInt(t.str()), t.loc())),
+			TRUE.map(t -> new Exp.Cnst(true, t.loc())),
+			FALSE.map(t -> new Exp.Cnst(false, t.loc())));
+
+	static final Peg<Exp> aExp = choice(
+			literal,
+			LCID.map(t -> new Exp.Var(t.str(), t.loc())),
+			ctorHead.map(t -> new Exp.Var(t.str(), t.loc())),
+			sequence(
+					LPAREN, exp_, RPAREN,
+					(s, exp, e) -> exp.updateLoc(locRange(s, e))));
+
+	static final Peg<Exp> appExp =
+			plus(aExp).map(l -> new Exp.App(l, locRange(l, l)));
+
+	static final Peg<Exp.Lamb> lambdaExp = sequence(
+			LAMBDA, plus(pattern), ARROW, mayBlock(exp_),
+			(s, pat, _, e) -> new Exp.Lamb(pat, e, locRange(s, e)));
+
+	static final Peg<Exp.Let> letExp = sequence(
+			LET, blockPlus(lazy(() -> valDecl())), SAMENT, IN, mayBlock(exp_),
+			(s, decls, _, _, e) -> new Exp.Let(decls, e, locRange(s, e)));
+
+	static final Peg<Exp.If> ifExp = choice(
+			sequence(IF, exp_, THEN, exp_, ELSE, exp_,  // one-line style
+					(s, c, _, e1, _, e2) -> new Exp.If(c, e1, e2, locRange(s, e2))),
+			sequence(IF, exp_, THEN, block(exp_), SAMENT, ELSE, block(exp_),  // two-block style
+					(s, c, _, e1, _, _, e2) -> new Exp.If(c, e1, e2, locRange(s, e2))));
+
+	static final Peg<CaseBranch> caseBranch = sequence(
+			pattern, ARROW, mayBlock(exp_),
+			(pat, _, e) -> new CaseBranch(pat, e, locRange(pat, e)));
+
+	static final Peg<Exp.Case> caseExp = sequence(
+			CASE, exp_, OF, blockPlus(caseBranch),
+			(s, c, _, cases) -> new Exp.Case(c, cases, locRange(s, cases)));
+
+	static final Peg<Exp> exp = choice(
+			appExp,
+			lambdaExp,
+			letExp,
+			ifExp,
+			caseExp);
+
+	private static Peg<Exp> exp() {
+		return exp;
 	}
 
-	private AnType.Var parseTyVar() {
-		Position start = current.pos();
-		String var = parse(LCID);
-		return new AnType.Var(var, location(start, end));
+	/* 宣言
+	 * <ctorImpl>   ::= <ctorHead> <ctorArg>*
+	 *
+	 * <variants>   ::= <ctorImpl>
+	 *                | (| <ctorImpl>)+
+	 *
+	 * <tyDecl>     ::= type <ctorHead> <tyVar>* = (| <ctorImpl>)+
+	 *
+	 * <tyAnno>     ::= <lcid> : <type>
+	 *
+	 * <valDecl>    ::= <tyAnno>? <lcid> <pattern>* = <exp>
+	 *
+	 * <topDecl>    ::= <tyDecl>
+	 *                | <valDecl>
+	 */
+	static final Peg<Constructor> ctorImpl = sequence(
+			UCID, star(ctorArg),
+			(name, args) -> new Constructor(name.str(), args, locRange(name, args)));
+
+	static final Peg<List<Constructor>> variants = choice(
+			join(ctorImpl, BAR),  // one-line style
+			blockPlus(sequence(BAR, ctorImpl, (_, v) -> v))); // multi-line style
+
+	static final Peg<Decl> tyDecl = sequence(
+			TYPE, UCID, star(tyVar), EQUAL, variants,
+			(s, name, vars, _, ctors) -> new TypeDecl(name.str(), vars, ctors, locRange(s, ctors)));
+
+	private record NameAndTyAnno(String name, AnType ty, Location loc) implements LocationHolder {};
+
+	static final Peg<NameAndTyAnno> tyAnno = sequence(
+			LCID, COLON, type, SAMENT,
+			(name, _, ty, _) -> new NameAndTyAnno(name.str(), ty, locRange(name, ty)));
+
+	static final Peg<Decl.ValDecl> valDecl = sequence(
+			optional(tyAnno), LCID, star(pattern), EQUAL, mayBlock(exp),
+			(maybe, name, args, _, e) -> {
+				if(maybe.isEmpty()) {
+					return new Decl.ValDecl(name.str(), Optional.empty(), args, e, locRange(name, e));
+				}
+				NameAndTyAnno anno = maybe.get();
+				if(!anno.name.equals(name.str())) {
+					todo("type annotaion name missmatch");
+				}
+				return new Decl.ValDecl(name.str(), Optional.of(anno.ty), args, e, locRange(anno, e));
+			});
+
+	private static Peg<Decl.ValDecl> valDecl() {
+		return valDecl;
 	}
 
+	// コンパイル単位
+	static final Peg<String> headLine = sequence(SAMENT, MODULE, UCID, (_, _, name) -> name.str());
 
+	static final Peg<Decl> topDecl = choice(
+			tyDecl,
+			valDecl);
 
-	private void nextToken() {
-		end = current.endPos();
-		current = next;
-		next = lexer.nextToken();
-
-		if(current.kind()==BR && cancelBr.contains(next.kind())) {
-			current = next;
-			next = lexer.nextToken();
-		}
-	}
-
-	private String parse(Kind expected) {
-		if(current.kind() == expected) {
-			String ret = current.value();
-			nextToken();
-			return ret;
-		} else {
-			throw new RuntimeException(
-					current.pos() + " cannot parse. "
-					+ "expected: " + expected
-					+ ", actual: " + current.kind());
-		}
-	}
-
-	private void consume(Kind expected) {
-		if(current.kind() == expected) {
-			nextToken();
-		} else {
-			throw new RuntimeException(
-					current.pos() + " cannot consume. "
-					+ "expected: " + expected
-					+ ", actual: " + current.kind());
-		}
-	}
-
-	private boolean maybeConsume(Kind expected) {
-		if(current.kind() == expected) {
-			nextToken();
-			return true;
-		}
-		return false;
-	}
-
-	private Location location(Position start, Position end) {
-		return new Location(lexer.getFileName(), start, end);
-	}
+	static final Peg<Module> module = sequence(
+			sequence(SAMENT, MODULE, UCID, (_, _, name) -> name.str()),
+			star(sequence(SAMENT, topDecl, (_, d) -> d)),
+			(name, decls) -> new Module(name, decls));
 }

--- a/src/main/java/zlk/parser/Peg.java
+++ b/src/main/java/zlk/parser/Peg.java
@@ -1,0 +1,438 @@
+package zlk.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * ソースからオブジェクトを読み取る解析表現文法パーサ.
+ * パーサは他のパーサと合成できる．
+ *
+ * @param <T> 解析結果オブジェクトの型
+ */
+public abstract class Peg<T> {
+
+	/**
+	 * パースが成功したが特に返すものが無いときに使う型
+	 */
+	public enum Unit {
+		INSTANCE;
+	}
+
+	/**
+	 * ソースからオブジェクトを読み取る．
+	 *
+	 * パースはソースの現在の読出し開始位置から行わる．
+	 * 呼出し後の読出し開始は，解析成功なら解析が終了した位置に進み，失敗時は未定義．
+	 *
+	 * @param src
+	 * @return 解析結果（解析失敗時はnull）
+	 */
+	public abstract T parse(Tokenized src);
+
+	public <R> Peg<R> map(Function<? super T, ? extends R> mapper) {
+		return new Peg<>() {
+			@Override
+			public R parse(Tokenized src) {
+				T t = Peg.this.parse(src);
+				if(t == null) {
+					return null;
+				}
+				return mapper.apply(t);
+			}
+		};
+	}
+
+	public static <T> Peg<T> lazy(
+			Supplier<Peg<? extends T>> supplier
+	) {
+		return new Peg<>() {
+			Peg<? extends T> peg = null;
+
+			@Override
+			public T parse(Tokenized src) {
+				if(peg == null) {
+					peg = supplier.get();
+				}
+				return peg.parse(src);
+			}
+
+		};
+	}
+
+	public static Peg<Token> kind(Token.Kind kind) {
+		return new Peg<>() {
+			@Override
+			public Token parse(Tokenized src) {
+				if(src.hasNext() && src.peek().kind == kind) {
+					return src.next();
+				}
+				return null;
+			}
+		};
+	}
+
+	public static <R, T1, T2> Peg<R> sequence(
+			Peg<T1> p1,
+			Peg<T2> p2,
+			BiFunction<? super T1, ? super T2, ? extends R> combiner) {
+		return new Peg<>() {
+			@Override
+			public R parse(Tokenized src) {
+				T1 r1 = p1.parse(src);
+				if(r1 == null) {
+					return null;
+				}
+				T2 r2 = p2.parse(src);
+				if(r2 == null) {
+					return null;
+				}
+				return combiner.apply(r1, r2);
+			}
+		};
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> Peg<T> choiceBase(
+			Peg<? extends T>... candidates
+	) {
+		return new Peg<>() {
+			@Override
+			public T parse(Tokenized src) {
+				int start = src.mark();
+				T r = null;
+				for(Peg<? extends T> p : candidates) {
+					r = p.parse(src);
+					if(r != null) {
+						return r;
+					}
+					src.jump(start);
+				}
+				return null;
+			}
+		};
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> Peg<T> choice(
+			Peg<? extends T> s1,
+			Peg<? extends T> s2
+	) {
+		return choiceBase(s1, s2);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> Peg<T> choice(
+			Peg<? extends T> s1,
+			Peg<? extends T> s2,
+			Peg<? extends T> s3
+	) {
+		return choiceBase(s1, s2, s3);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> Peg<T> choice(
+			Peg<? extends T> s1,
+			Peg<? extends T> s2,
+			Peg<? extends T> s3,
+			Peg<? extends T> s4
+	) {
+		return choiceBase(s1, s2, s3, s4);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> Peg<T> choice(
+			Peg<? extends T> s1,
+			Peg<? extends T> s2,
+			Peg<? extends T> s3,
+			Peg<? extends T> s4,
+			Peg<? extends T> s5
+	) {
+		return choiceBase(s1, s2, s3, s4, s5);
+	}
+
+	public static <T> Peg<List<T>> star(Peg<T> p) {
+		return new Peg<>() {
+			@Override
+			public List<T> parse(Tokenized src) {
+				List<T> result = new ArrayList<>();
+				while(true) {
+					int start = src.mark();
+					T r = p.parse(src);
+					if(r == null) {
+						src.jump(start);
+						return result;
+					}
+					result.add(r);
+				}
+			}
+		};
+	}
+
+	public static <T> Peg<List<T>> plus(Peg<T> p) {
+		return new Peg<>() {
+			@Override
+			public List<T> parse(Tokenized src) {
+				List<T> result = new ArrayList<>();
+				T r = p.parse(src);
+				if(r == null) {
+					return null;
+				}
+				result.add(r);
+				while(true) {
+					int start = src.mark();
+					r = p.parse(src);
+					if(r == null) {
+						src.jump(start);
+						return result;
+					}
+					result.add(r);
+				}
+			}
+		};
+	}
+
+	public static <T> Peg<Optional<T>> optional(Peg<T> p) {
+		return new Peg<>() {
+			@Override
+			public Optional<T> parse(Tokenized src) {
+				int start = src.mark();
+				T r = p.parse(src);
+				if(r == null) {
+					src.jump(start);
+					return Optional.empty();
+				}
+				return Optional.of(r);
+			}
+		};
+	}
+
+	public static Peg<Unit> andPred(Peg<?> p) {
+		return new Peg<>() {
+			@Override
+			public Unit parse(Tokenized src) {
+				int mark = src.mark();
+				if(p.parse(src) != null) {
+					src.jump(mark);
+					return Unit.INSTANCE;
+				}
+				return null;
+			}
+		};
+	}
+
+	public static Peg<Unit> notPred(Peg<?> p) {
+		return new Peg<>() {
+			@Override
+			public Unit parse(Tokenized src) {
+				int mark = src.mark();
+				if(p.parse(src) == null) {
+					src.jump(mark);
+					return Unit.INSTANCE;
+				}
+				return null;
+			}
+		};
+	}
+	public static <R, T1, T2, T3> Peg<R> sequence(
+			Peg<T1> p1,
+			Peg<T2> p2,
+			Peg<T3> p3,
+			Function3<? super T1, ? super T2, ? super T3, ? extends R> combiner) {
+		return new Peg<>() {
+			@Override
+			public R parse(Tokenized src) {
+				T1 r1 = p1.parse(src);
+				if(r1 == null) {
+					return null;
+				}
+				T2 r2 = p2.parse(src);
+				if(r2 == null) {
+					return null;
+				}
+				T3 r3 = p3.parse(src);
+				if(r3 == null) {
+					return null;
+				}
+				return combiner.apply(r1, r2, r3);
+			}
+		};
+	}
+	public static <R, T1, T2, T3, T4> Peg<R> sequence(
+			Peg<T1> p1,
+			Peg<T2> p2,
+			Peg<T3> p3,
+			Peg<T4> p4,
+			Function4<? super T1, ? super T2, ? super T3, ? super T4, ? extends R> combiner) {
+		return new Peg<>() {
+			@Override
+			public R parse(Tokenized src) {
+				T1 r1 = p1.parse(src);
+				if(r1 == null) {
+					return null;
+				}
+				T2 r2 = p2.parse(src);
+				if(r2 == null) {
+					return null;
+				}
+				T3 r3 = p3.parse(src);
+				if(r3 == null) {
+					return null;
+				}
+				T4 r4 = p4.parse(src);
+				if(r4 == null) {
+					return null;
+				}
+				return combiner.apply(r1, r2, r3, r4);
+			}
+		};
+	}
+
+	public static <R, T1, T2, T3, T4, T5> Peg<R> sequence(
+			Peg<T1> p1,
+			Peg<T2> p2,
+			Peg<T3> p3,
+			Peg<T4> p4,
+			Peg<T5> p5,
+			Function5<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? extends R> combiner) {
+		return new Peg<>() {
+			@Override
+			public R parse(Tokenized src) {
+				T1 r1 = p1.parse(src);
+				if(r1 == null) {
+					return null;
+				}
+				T2 r2 = p2.parse(src);
+				if(r2 == null) {
+					return null;
+				}
+				T3 r3 = p3.parse(src);
+				if(r3 == null) {
+					return null;
+				}
+				T4 r4 = p4.parse(src);
+				if(r4 == null) {
+					return null;
+				}
+				T5 r5 = p5.parse(src);
+				if(r5 == null) {
+					return null;
+				}
+				return combiner.apply(r1, r2, r3, r4, r5);
+			}
+		};
+	}
+
+	public static <R, T1, T2, T3, T4, T5, T6> Peg<R> sequence(
+			Peg<T1> p1,
+			Peg<T2> p2,
+			Peg<T3> p3,
+			Peg<T4> p4,
+			Peg<T5> p5,
+			Peg<T6> p6,
+			Function6<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? extends R> combiner) {
+		return new Peg<>() {
+			@Override
+			public R parse(Tokenized src) {
+				T1 r1 = p1.parse(src);
+				if(r1 == null) {
+					return null;
+				}
+				T2 r2 = p2.parse(src);
+				if(r2 == null) {
+					return null;
+				}
+				T3 r3 = p3.parse(src);
+				if(r3 == null) {
+					return null;
+				}
+				T4 r4 = p4.parse(src);
+				if(r4 == null) {
+					return null;
+				}
+				T5 r5 = p5.parse(src);
+				if(r5 == null) {
+					return null;
+				}
+				T6 r6 = p6.parse(src);
+				if(r6 == null) {
+					return null;
+				}
+				return combiner.apply(r1, r2, r3, r4, r5, r6);
+			}
+		};
+	}
+
+	public static <R, T1, T2, T3, T4, T5, T6, T7> Peg<R> sequence(
+			Peg<T1> p1,
+			Peg<T2> p2,
+			Peg<T3> p3,
+			Peg<T4> p4,
+			Peg<T5> p5,
+			Peg<T6> p6,
+			Peg<T7> p7,
+			Function7<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? extends R> combiner) {
+		return new Peg<>() {
+			@Override
+			public R parse(Tokenized src) {
+				T1 r1 = p1.parse(src);
+				if(r1 == null) {
+					return null;
+				}
+				T2 r2 = p2.parse(src);
+				if(r2 == null) {
+					return null;
+				}
+				T3 r3 = p3.parse(src);
+				if(r3 == null) {
+					return null;
+				}
+				T4 r4 = p4.parse(src);
+				if(r4 == null) {
+					return null;
+				}
+				T5 r5 = p5.parse(src);
+				if(r5 == null) {
+					return null;
+				}
+				T6 r6 = p6.parse(src);
+				if(r6 == null) {
+					return null;
+				}
+				T7 r7 = p7.parse(src);
+				if(r7 == null) {
+					return null;
+				}
+				return combiner.apply(r1, r2, r3, r4, r5, r6, r7);
+			}
+		};
+	}
+}
+
+@FunctionalInterface
+interface Function3<T1, T2, T3, R> {
+	R apply(T1 t1, T2 t2, T3 t3);
+}
+
+@FunctionalInterface
+interface Function4<T1, T2, T3, T4, R> {
+	R apply(T1 t1, T2 t2, T3 t3, T4 t4);
+}
+
+@FunctionalInterface
+interface Function5<T1, T2, T3, T4, T5, R> {
+	R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5);
+}
+
+@FunctionalInterface
+interface Function6<T1, T2, T3, T4, T5, T6, R> {
+	R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6);
+}
+
+@FunctionalInterface
+interface Function7<T1, T2, T3, T4, T5, T6, T7, R> {
+	R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7);
+}

--- a/src/main/java/zlk/parser/Source.java
+++ b/src/main/java/zlk/parser/Source.java
@@ -1,0 +1,32 @@
+package zlk.parser;
+
+import java.util.Arrays;
+
+import zlk.util.Position;
+
+public final class Source {
+	public final String fileName;
+	public final String content;
+	int[] lineStartIndexes = null;
+
+	public Source(String fileName, String src) {
+		this.fileName = fileName;
+		this.content = src;
+	}
+
+	public Position getPosition(int charIdx) {
+		int lineIdx = Arrays.binarySearch(lineStartIndexes, charIdx);
+		if(lineIdx < 0) {
+			lineIdx = -lineIdx - 2;
+		}
+		return new Position(lineIdx + 1, charIdx - lineStartIndexes[lineIdx] + 1);
+	}
+
+	public int getLine(int charIdx) {
+		int lineIdx = Arrays.binarySearch(lineStartIndexes, charIdx);
+		if(lineIdx < 0) {
+			lineIdx = -lineIdx - 2;
+		}
+		return lineIdx + 1;
+	}
+}

--- a/src/main/java/zlk/parser/Token.java
+++ b/src/main/java/zlk/parser/Token.java
@@ -1,19 +1,27 @@
 package zlk.parser;
 
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import zlk.util.Position;
+import zlk.util.Location;
+import zlk.util.LocationHolder;
 
-public record Token(Kind kind, String value, Position pos) {
+public final class Token implements LocationHolder {
+	private final Source info;
+	public final Kind kind;
+	public final int start;
+	public final int end;
 
 	public enum Kind {
 		UCID(""),
 		LCID(""),
 		DIGITS(""),
-		BR(""),
-		EOF(""),
+
+		ENDENT(""),
+		DEDENT(""),
+		SAMENT(""),  // no indentation change
+
 		ILL(""),
 
 		ARROW     ("->"),
@@ -23,7 +31,6 @@ public record Token(Kind kind, String value, Position pos) {
 		LAMBDA    ("\\"),
 		LPAREN    ("("),
 		RPAREN    (")"),
-		UNIT      ("()"),
 
 		TRUE("true"),
 		FALSE("false"),
@@ -38,8 +45,21 @@ public record Token(Kind kind, String value, Position pos) {
 		ELSE("else"),
 		;
 
+		private static final Map<Character, Kind> punctuatorLookup =
+				Stream.of(
+						ARROW,
+						BAR,
+						COLON,
+						EQUAL,
+						LAMBDA,
+						LPAREN,
+						RPAREN)
+				.collect(Collectors.toMap(
+						k -> k.str().charAt(0),  // 1文字目が被ったら実行時例外
+						k -> k));
+
 		private static final Map<String, Kind> keywordLookup =
-				List.of(
+				Stream.of(
 						TRUE,
 						FALSE,
 						MODULE,
@@ -50,9 +70,7 @@ public record Token(Kind kind, String value, Position pos) {
 						OF,
 						IF,
 						THEN,
-						ELSE
-						)
-				.stream()
+						ELSE)
 				.collect(Collectors.toMap(Kind::str, t -> t));
 
 		private final String str;
@@ -65,25 +83,44 @@ public record Token(Kind kind, String value, Position pos) {
 			return str;
 		}
 
-		public static Kind lookupKeywordType(String id) {
+		/**
+		 * srcのoffsetの位置からはじまるpunctuatorがあればそれを返す．なければnull．
+		 * @param src
+		 * @param offset
+		 * @return
+		 */
+		public static Kind lookupPunctuator(String src, int offset) {
+			Kind kind = punctuatorLookup.getOrDefault(src.charAt(offset), null);
+			if(kind != null && src.startsWith(kind.str, offset)) {
+				return kind;
+			}
+			return null;
+		}
+
+		public static Kind lookupKeyword(String id) {
 			return keywordLookup.getOrDefault(id, null);
 		}
 	}
 
-	public Token(Kind kind, Position pos) {
-		this(kind, kind.str(), pos);
+	public Token(Source info, Kind kind, int start, int end) {
+		this.info = info;
+		this.kind = kind;
+		this.start = start;
+		this.end = end;
 	}
 
-	public int line() {
-		return pos.line();
+	public String str() {
+		return info.content.substring(start, end);
 	}
 
-	public int column() {
-		return pos.column();
+	@Override
+	public Location loc() {
+		return new Location(info, start, end);
 	}
 
-	public Position endPos() {
-		int codepoints = value.codePointCount(0, value.length());
-		return new Position(line(), column() + codepoints);
+	// TODO 試したら消してよい
+	@Override
+	public String toString() {
+		return kind + ": \"" + str() + "\" " + loc();
 	}
 }

--- a/src/main/java/zlk/parser/Tokenized.java
+++ b/src/main/java/zlk/parser/Tokenized.java
@@ -1,0 +1,98 @@
+package zlk.parser;
+
+import java.util.NoSuchElementException;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+/**
+ * 字句解析の結果をPEGパーサから利用するための形式
+ */
+public final class Tokenized {
+	private final Token[] tokens;
+	private int idx;
+
+	public Tokenized(Token[] tokens) {
+		this.tokens = tokens;
+		this.idx = 0;
+	}
+
+	/**
+	 * 全トークン数を返す．
+	 * @return このソースのトークン数
+	 */
+	public int length() {
+		return tokens.length;
+	}
+
+	/**
+	 * 現在の読み取り位置からさらにトークンを読み取れるかどうかを返す．
+	 * @return 読み取ればtrue
+	 */
+	public boolean hasNext() {
+		return idx < tokens.length;
+	}
+
+	/**
+	 * 現在の読み取り位置から1トークン読み取り，読み取り位置を1つ進める．
+	 * @return トークン
+	 * @throws NoSuchElementException トークンが無い場合
+	 */
+	public Token next() {
+		if(!hasNext()) {
+			throw new NoSuchElementException();
+		}
+		return tokens[idx++];
+	}
+
+	/**
+	 * 現在の読み取り位置から1トークン読み取るが読取り位置は進めない．
+	 * @return トークン
+	 * @throws NoSuchElementException トークンが無い場合
+	 */
+	public Token peek() {
+		if(!hasNext()) {
+			throw new NoSuchElementException();
+		}
+		return tokens[idx];
+	}
+
+	/**
+	 * このソースの現在の読み取り位置を返す．
+	 * @return 現在の読み取り位置
+	 */
+	public int mark() {
+		return idx;
+	}
+
+	/**
+	 * このソースの読み取り位置を指定する.
+	 * @param index インデックス
+	 * @throws IndexOutOfBoundsException 指定した位置が無効な場合
+	 */
+	public void jump(int index) {
+		if(index < 0 || tokens.length < idx) {
+			throw new IndexOutOfBoundsException("index: "+index+", length: "+tokens.length);
+		}
+		idx = index;
+	}
+
+	public void forEach(Consumer<? super Token> action) {
+		Stream.of(tokens).forEach(action);
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("idx: ").append(idx).append(", tokens: [");
+		boolean first = true;
+		for(Token token : tokens) {
+			if(!first) {
+				sb.append(", ");
+			}
+			sb.append(token);
+			first = false;
+		}
+		sb.append("]");
+		return sb.toString();
+	}
+}

--- a/src/main/java/zlk/util/ChunkedBuffer.java
+++ b/src/main/java/zlk/util/ChunkedBuffer.java
@@ -1,0 +1,124 @@
+package zlk.util;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+
+public class ChunkedBuffer<E> {
+	private static final int DEFAULT_HEAD_CHUNK_SIZE = 10;
+
+	private final IntFunction<E[]> arrayBuilder;
+	private final List<E[]> chunks = new ArrayList<>();
+	private E[] tailChunk;  // length == chunkSize, null if not initialized
+	private int tailSize;   // 0..chunkSize
+	private int size;
+
+	public ChunkedBuffer(IntFunction<E[]> arrayBuilder) {
+		this(arrayBuilder, DEFAULT_HEAD_CHUNK_SIZE);
+	}
+
+	public ChunkedBuffer(IntFunction<E[]> arrayBuilder, int initialCapacity) {
+		this.arrayBuilder = arrayBuilder;
+		int cap = Math.max(initialCapacity, DEFAULT_HEAD_CHUNK_SIZE);
+		tailChunk = arrayBuilder.apply(cap);
+		chunks.add(tailChunk);
+		tailSize = 0;
+		size = 0;
+	}
+
+	public void add(E e) {
+		if (tailSize == tailChunk.length) { // tail is full
+			int newCap = tailChunk.length + (tailChunk.length >> 1);
+			tailChunk = arrayBuilder.apply(newCap);
+			chunks.add(tailChunk);
+			tailSize = 0;
+		}
+		tailChunk[tailSize++] = e;
+		size++;
+	}
+
+	public int size() {
+		return size;
+	}
+
+	public void forEach(Consumer<E> action) {
+		Objects.requireNonNull(action);
+
+		int last = chunks.size() - 1;
+		for (int i = 0; i < last; i++) {
+			E[] chunk = chunks.get(i);
+			for (int j = 0; j < chunk.length; j++) {
+				action.accept(chunk[j]);
+			}
+		}
+		for (int i = 0; i < tailSize; i++) {
+			action.accept(tailChunk[i]);
+		}
+	}
+
+	public E[] toArray() {
+		E[] result = arrayBuilder.apply(size);
+		int copied = 0;
+
+		int last = chunks.size() - 1;
+		for (int i = 0; i < last; i++) {
+			E[] chunk = chunks.get(i);
+			System.arraycopy(chunk, 0, result, copied, chunk.length);
+			copied += chunk.length;
+		}
+		System.arraycopy(tailChunk, 0, result, copied, tailSize);
+		assert copied + tailSize == size;
+		return result;
+	}
+
+	public List<E> toList() {
+		List<E> result = new ArrayList<>(size);
+		int copied = 0;
+
+		int last = chunks.size() - 1;
+		for (int i = 0; i < last; i++) {
+			E[] chunk = chunks.get(i);
+			result.addAll(List.of(chunk));
+			copied += chunk.length;
+		}
+		result.addAll(List.of(tailChunk));
+		assert copied + tailSize == size;
+		return result;
+	}
+
+	public Iterator<E> iterator() {
+		return new Iterator<>() {
+			private int consumed = 0;
+			private int chunkIndex = 0;
+			private int indexInChunk = 0;
+
+			@Override
+			public boolean hasNext() {
+				return consumed < size;
+			}
+
+			@Override
+			public E next() {
+				if (!hasNext()) {
+					throw new NoSuchElementException();
+				}
+
+				E[] chunk = chunks.get(chunkIndex);
+				int limit = (chunkIndex == chunks.size() - 1) ? tailSize : chunk.length;
+
+				if (indexInChunk >= limit) {
+					chunkIndex++;
+					indexInChunk = 0;
+					chunk = chunks.get(chunkIndex);
+				}
+
+				consumed++;
+				return chunk[indexInChunk++];
+			}
+		};
+	}
+}

--- a/src/main/java/zlk/util/IntChunkedBuffer.java
+++ b/src/main/java/zlk/util/IntChunkedBuffer.java
@@ -1,0 +1,110 @@
+package zlk.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.PrimitiveIterator;
+import java.util.function.IntConsumer;
+
+/**
+ * 要素数の不明なintを一時的に集約するための構造．
+ * 集約フェーズのあとの読取りフェーズが完全に分離されていることを想定している．
+ */
+public final class IntChunkedBuffer {
+	private static final int DEFAULT_HEAD_CHUNK_SIZE = 10;
+
+	private final List<int[]> chunks = new ArrayList<>();
+	private int[] tailChunk; // length == chunkSize, null if not initialized
+	private int tailSize; // 0..chunkSize
+	private int size;
+
+	public IntChunkedBuffer() {
+		this(DEFAULT_HEAD_CHUNK_SIZE);
+	}
+
+	public IntChunkedBuffer(int initialCapacity) {
+		int cap = Math.max(initialCapacity, DEFAULT_HEAD_CHUNK_SIZE);
+		tailChunk = new int[cap];
+		chunks.add(tailChunk);
+		tailSize = 0;
+		size = 0;
+	}
+
+	public void add(int e) {
+		if (tailSize == tailChunk.length) { // tail is full
+			int newCap = tailChunk.length + (tailChunk.length >> 1);
+			tailChunk = new int[newCap];
+			chunks.add(tailChunk);
+			tailSize = 0;
+		}
+		tailChunk[tailSize++] = e;
+		size++;
+	}
+
+	public int size() {
+		return size;
+	}
+
+	public void forEach(IntConsumer action) {
+		Objects.requireNonNull(action);
+
+		int last = chunks.size() - 1;
+		for (int i = 0; i < last; i++) {
+			int[] chunk = chunks.get(i);
+			for (int j = 0; j < chunk.length; j++) {
+				action.accept(chunk[j]);
+			}
+		}
+		for (int i = 0; i < tailSize; i++) {
+			action.accept(tailChunk[i]);
+		}
+	}
+
+	public int[] toArray() {
+		int[] result = new int[size];
+		int copied = 0;
+
+		int last = chunks.size() - 1;
+		for (int i = 0; i < last; i++) {
+			int[] chunk = chunks.get(i);
+			System.arraycopy(chunk, 0, result, copied, chunk.length);
+			copied += chunk.length;
+		}
+		System.arraycopy(tailChunk, 0, result, copied, tailSize);
+		assert copied + tailSize == size;
+		return result;
+	}
+
+	public PrimitiveIterator.OfInt iterator() {
+		return new PrimitiveIterator.OfInt() {
+			private int consumed = 0;
+			private int chunkIndex = 0;
+			private int indexInChunk = 0;
+
+			@Override
+			public boolean hasNext() {
+				return consumed < size;
+			}
+
+			@Override
+			public int nextInt() {
+				if (!hasNext()) {
+					throw new NoSuchElementException();
+				}
+
+				int[] chunk = chunks.get(chunkIndex);
+				int limit = (chunkIndex == chunks.size() - 1) ? tailSize : chunk.length;
+
+				if (indexInChunk >= limit) {
+					chunkIndex++;
+					indexInChunk = 0;
+					chunk = chunks.get(chunkIndex);
+				}
+
+				consumed++;
+				return chunk[indexInChunk++];
+			}
+		};
+	}
+}

--- a/src/main/java/zlk/util/Location.java
+++ b/src/main/java/zlk/util/Location.java
@@ -1,32 +1,52 @@
 package zlk.util;
 
+import zlk.parser.Source;
 import zlk.util.pp.PrettyPrintable;
 import zlk.util.pp.PrettyPrinter;
 
 /**
  * 構文要素のソースコード上の範囲
+ * 表示はエディタ用で内部表現はchar index
  * @author YuyaAizawa
  *
  */
-public record Location(
-		String filename,
-		Position start,
-		Position end
-) implements PrettyPrintable {
+public final class Location implements PrettyPrintable {
 
-	private static final Location NO_LOC = new Location(null, null, null);
+	private final Source src;
+	private final int start;  // inclusive
+	private final int end;    // exclusive
+
+	public Location(Source src, int start, int end) {
+		this.src = src;
+		this.start = start;
+		this.end = end;
+	}
+
+	private static final Location NO_LOC = new Location(null, 0, 0);
 	public static final Location noLocation() {
 		return NO_LOC;
 	}
 
+	public static Location range(Location from, Location to) {
+		if(from == NO_LOC) { return to; }
+		if(to == NO_LOC) { return from; }
+
+		if(from.src != to.src) {
+			throw new IllegalArgumentException(
+					"src not match: "+from.src.fileName+" /= "+to.src.fileName);
+		}
+		if(from.start > to.end) {
+			throw new IllegalArgumentException(
+					"invalid char index: "+from.start+" > "+to.end);
+		}
+		return new Location(from.src, from.start, to.end);
+	}
+
 	@Override
 	public void mkString(PrettyPrinter pp) {
-		pp.append(filename).append(":").append(start()).append("-");
-		if(start.line() == end.line()) {
-			pp.append(end().column());
-		} else {
-			pp.append(end());
-		}
+		Position start = src.getPosition(this.start);
+		Position end = src.getPosition(this.end);
+		pp.append(start).append("-").append(end).append("@").append(src.fileName);
 	}
 
 	@Override

--- a/src/test/java/zlk/ConstrainerTest.java
+++ b/src/test/java/zlk/ConstrainerTest.java
@@ -54,30 +54,42 @@ public class ConstrainerTest {
 				                        Local: Main.fact.n = [5],
 				                        [6] = Bool,
 				                      ],
-				                    I32 = [3],
+				                    Exists:
+				                      vars: [[7], [8]]
+				                      cons: [
+				                        I32 = [7],
+				                        [7] = [8],
+				                        [8] = [3],
+				                      ],
 				                    Let:
 				                      rigids: []
 				                      flexes: []
 				                      header: {
-				                        Main.fact.nn: [15],
-				                        Main.fact.one: [14],
+				                        Main.fact.nn: [17],
+				                        Main.fact.one: [16],
 				                      }
 				                      headerCons: [
 				                        Phase:
 				                          cons: [
 				                            Let:
 				                              rigids: []
-				                              flexes: [[16]]
+				                              flexes: [[18]]
 				                              header: {}
 				                              headerCons: [
 				                                Phase:
 				                                  cons: [
-				                                    I32 = [16],
+				                                    Exists:
+				                                      vars: [[19], [20]]
+				                                      cons: [
+				                                        I32 = [19],
+				                                        [19] = [20],
+				                                        [20] = [18],
+				                                      ],
 				                                  ]
 				                                  genTargets: [],
 				                              ]
 				                              bodyCons:[
-				                                [16] = [14],
+				                                [18] = [16],
 				                              ],
 				                          ]
 				                          genTargets: [Main.fact.one],
@@ -85,45 +97,45 @@ public class ConstrainerTest {
 				                          cons: [
 				                            Let:
 				                              rigids: []
-				                              flexes: [[17]]
+				                              flexes: [[21]]
 				                              header: {}
 				                              headerCons: [
 				                                Phase:
 				                                  cons: [
 				                                    Exists:
-				                                      vars: [[18], [19], [20], [21]]
+				                                      vars: [[22], [23], [24], [25]]
 				                                      cons: [
-				                                        Foreign: Basic.sub:I32 -> I32 -> I32 = [18],
-				                                        [18] = [19] -> [20] -> [21],
-				                                        Local: Main.fact.n = [19],
-				                                        Local: Main.fact.one = [20],
-				                                        [21] = [17],
+				                                        Foreign: Basic.sub:I32 -> I32 -> I32 = [22],
+				                                        [22] = [23] -> [24] -> [25],
+				                                        Local: Main.fact.n = [23],
+				                                        Local: Main.fact.one = [24],
+				                                        [25] = [21],
 				                                      ],
 				                                  ]
 				                                  genTargets: [],
 				                              ]
 				                              bodyCons:[
-				                                [17] = [15],
+				                                [21] = [17],
 				                              ],
 				                          ]
 				                          genTargets: [Main.fact.nn],
 				                      ]
 				                      bodyCons:[
 				                        Exists:
-				                          vars: [[7], [8], [9], [13]]
+				                          vars: [[9], [10], [11], [15]]
 				                          cons: [
-				                            Foreign: Basic.mul:I32 -> I32 -> I32 = [7],
-				                            [7] = [8] -> [9] -> [13],
-				                            Local: Main.fact.n = [8],
+				                            Foreign: Basic.mul:I32 -> I32 -> I32 = [9],
+				                            [9] = [10] -> [11] -> [15],
+				                            Local: Main.fact.n = [10],
 				                            Exists:
-				                              vars: [[10], [11], [12]]
+				                              vars: [[12], [13], [14]]
 				                              cons: [
-				                                Local: Main.fact = [10],
-				                                [10] = [11] -> [12],
-				                                Local: Main.fact.nn = [11],
-				                                [12] = [9],
+				                                Local: Main.fact = [12],
+				                                [12] = [13] -> [14],
+				                                Local: Main.fact.nn = [13],
+				                                [14] = [11],
 				                              ],
-				                            [13] = [3],
+				                            [15] = [3],
 				                          ],
 				                      ],
 				                    [3] = [2],
@@ -176,48 +188,54 @@ public class ConstrainerTest {
 				      cons: [
 				        Let:
 				          rigids: []
-				          flexes: [[15], [16]]
+				          flexes: [[17], [18]]
 				          header: {
-				            Main.isOdd.n: [15],
+				            Main.isOdd.n: [17],
 				          }
 				          headerCons: [
 				            Phase:
 				              cons: [
 				                Exists:
-				                  vars: [[17]]
+				                  vars: [[19]]
 				                  cons: [
 				                    Exists:
-				                      vars: [[18], [19], [20]]
+				                      vars: [[20], [21], [22]]
 				                      cons: [
-				                        Foreign: Basic.isZero:I32 -> Bool = [18],
-				                        [18] = [19] -> [20],
-				                        Local: Main.isOdd.n = [19],
-				                        [20] = Bool,
+				                        Foreign: Basic.isZero:I32 -> Bool = [20],
+				                        [20] = [21] -> [22],
+				                        Local: Main.isOdd.n = [21],
+				                        [22] = Bool,
 				                      ],
-				                    Foreign: Basic.False:Bool = [17],
 				                    Exists:
-				                      vars: [[21], [22], [27]]
+				                      vars: [[23], [24]]
 				                      cons: [
-				                        Local: Main.isEven = [21],
-				                        [21] = [22] -> [27],
-				                        Exists:
-				                          vars: [[23], [24], [25], [26]]
-				                          cons: [
-				                            Foreign: Basic.sub:I32 -> I32 -> I32 = [23],
-				                            [23] = [24] -> [25] -> [26],
-				                            Local: Main.isOdd.n = [24],
-				                            I32 = [25],
-				                            [26] = [22],
-				                          ],
-				                        [27] = [17],
+				                        Foreign: Basic.False:Bool = [23],
+				                        [23] = [24],
+				                        [24] = [19],
 				                      ],
-				                    [17] = [16],
+				                    Exists:
+				                      vars: [[25], [26], [31]]
+				                      cons: [
+				                        Local: Main.isEven = [25],
+				                        [25] = [26] -> [31],
+				                        Exists:
+				                          vars: [[27], [28], [29], [30]]
+				                          cons: [
+				                            Foreign: Basic.sub:I32 -> I32 -> I32 = [27],
+				                            [27] = [28] -> [29] -> [30],
+				                            Local: Main.isOdd.n = [28],
+				                            I32 = [29],
+				                            [30] = [26],
+				                          ],
+				                        [31] = [19],
+				                      ],
+				                    [19] = [18],
 				                  ],
 				              ]
 				              genTargets: [],
 				          ]
 				          bodyCons:[
-				            [15] -> [16] = [1],
+				            [17] -> [18] = [1],
 				          ],
 				        Let:
 				          rigids: []
@@ -239,22 +257,28 @@ public class ConstrainerTest {
 				                        Local: Main.isEven.n = [6],
 				                        [7] = Bool,
 				                      ],
-				                    Foreign: Basic.True:Bool = [4],
 				                    Exists:
-				                      vars: [[8], [9], [14]]
+				                      vars: [[8], [9]]
 				                      cons: [
-				                        Local: Main.isOdd = [8],
-				                        [8] = [9] -> [14],
+				                        Foreign: Basic.True:Bool = [8],
+				                        [8] = [9],
+				                        [9] = [4],
+				                      ],
+				                    Exists:
+				                      vars: [[10], [11], [16]]
+				                      cons: [
+				                        Local: Main.isOdd = [10],
+				                        [10] = [11] -> [16],
 				                        Exists:
-				                          vars: [[10], [11], [12], [13]]
+				                          vars: [[12], [13], [14], [15]]
 				                          cons: [
-				                            Foreign: Basic.sub:I32 -> I32 -> I32 = [10],
-				                            [10] = [11] -> [12] -> [13],
-				                            Local: Main.isEven.n = [11],
-				                            I32 = [12],
-				                            [13] = [9],
+				                            Foreign: Basic.sub:I32 -> I32 -> I32 = [12],
+				                            [12] = [13] -> [14] -> [15],
+				                            Local: Main.isEven.n = [13],
+				                            I32 = [14],
+				                            [15] = [11],
 				                          ],
-				                        [14] = [4],
+				                        [16] = [4],
 				                      ],
 				                    [4] = [3],
 				                  ],
@@ -279,15 +303,15 @@ public class ConstrainerTest {
 	void genericTypeInLetExp() {
 		String src ="""
 				type IntList =
-				| Nil
-				| Cons I32 IntList
+				  | Nil
+				  | Cons I32 IntList
 
 				car list =
 				  case list of
-				  | Nil ->
-				    0
-				  | Cons hd tl ->
-				    hd
+				    Nil ->
+				      0
+				    Cons hd tl ->
+				      hd
 
 				rectest =
 				  let
@@ -322,9 +346,15 @@ public class ConstrainerTest {
 				            Phase:
 				              cons: [
 				                Exists:
-				                  vars: [[4], [5]]
+				                  vars: [[4], [7]]
 				                  cons: [
-				                    Local: Main.car.list = [4],
+				                    Exists:
+				                      vars: [[5], [6]]
+				                      cons: [
+				                        Local: Main.car.list = [5],
+				                        [5] = [6],
+				                        [6] = [4],
+				                      ],
 				                    Let:
 				                      rigids: []
 				                      flexes: []
@@ -333,12 +363,18 @@ public class ConstrainerTest {
 				                        Phase:
 				                          cons: [
 				                            Main.IntList = [4],
-				                            I32 = [5],
+				                            Exists:
+				                              vars: [[8], [9]]
+				                              cons: [
+				                                I32 = [8],
+				                                [8] = [9],
+				                                [9] = [7],
+				                              ],
 				                          ]
 				                          genTargets: [],
 				                      ]
 				                      bodyCons:[
-				                        [5] = [5],
+				                        [7] = [7],
 				                      ],
 				                    Let:
 				                      rigids: []
@@ -351,14 +387,20 @@ public class ConstrainerTest {
 				                        Phase:
 				                          cons: [
 				                            Main.IntList = [4],
-				                            Local: Main.car._1.hd = [5],
+				                            Exists:
+				                              vars: [[10], [11]]
+				                              cons: [
+				                                Local: Main.car._1.hd = [10],
+				                                [10] = [11],
+				                                [11] = [7],
+				                              ],
 				                          ]
 				                          genTargets: [],
 				                      ]
 				                      bodyCons:[
-				                        [5] = [5],
+				                        [7] = [7],
 				                      ],
-				                    [5] = [3],
+				                    [7] = [3],
 				                  ],
 				              ]
 				              genTargets: [],
@@ -372,7 +414,7 @@ public class ConstrainerTest {
 				      cons: [
 				        Let:
 				          rigids: []
-				          flexes: [[6]]
+				          flexes: [[12]]
 				          header: {}
 				          headerCons: [
 				            Phase:
@@ -381,27 +423,33 @@ public class ConstrainerTest {
 				                  rigids: []
 				                  flexes: []
 				                  header: {
-				                    Main.rectest.id: [7],
-				                    Main.rectest.res: [8],
+				                    Main.rectest.id: [15],
+				                    Main.rectest.res: [16],
 				                  }
 				                  headerCons: [
 				                    Phase:
 				                      cons: [
 				                        Let:
 				                          rigids: []
-				                          flexes: [[9], [10]]
+				                          flexes: [[17], [18]]
 				                          header: {
-				                            Main.rectest.id.x: [9],
+				                            Main.rectest.id.x: [17],
 				                          }
 				                          headerCons: [
 				                            Phase:
 				                              cons: [
-				                                Local: Main.rectest.id.x = [10],
+				                                Exists:
+				                                  vars: [[19], [20]]
+				                                  cons: [
+				                                    Local: Main.rectest.id.x = [19],
+				                                    [19] = [20],
+				                                    [20] = [18],
+				                                  ],
 				                              ]
 				                              genTargets: [],
 				                          ]
 				                          bodyCons:[
-				                            [9] -> [10] = [7],
+				                            [17] -> [18] = [15],
 				                          ],
 				                      ]
 				                      genTargets: [Main.rectest.id],
@@ -409,74 +457,80 @@ public class ConstrainerTest {
 				                      cons: [
 				                        Let:
 				                          rigids: []
-				                          flexes: [[11]]
+				                          flexes: [[21]]
 				                          header: {}
 				                          headerCons: [
 				                            Phase:
 				                              cons: [
 				                                Exists:
-				                                  vars: [[12], [13], [17], [32]]
+				                                  vars: [[22], [23], [27], [42]]
 				                                  cons: [
-				                                    Foreign: Main.Cons:I32 -> Main.IntList -> Main.IntList = [12],
-				                                    [12] = [13] -> [17] -> [32],
+				                                    Foreign: Main.Cons:I32 -> Main.IntList -> Main.IntList = [22],
+				                                    [22] = [23] -> [27] -> [42],
 				                                    Exists:
-				                                      vars: [[14], [15], [16]]
+				                                      vars: [[24], [25], [26]]
 				                                      cons: [
-				                                        Local: Main.rectest.id = [14],
-				                                        [14] = [15] -> [16],
-				                                        I32 = [15],
-				                                        [16] = [13],
+				                                        Local: Main.rectest.id = [24],
+				                                        [24] = [25] -> [26],
+				                                        I32 = [25],
+				                                        [26] = [23],
 				                                      ],
 				                                    Exists:
-				                                      vars: [[18], [19], [30], [31]]
+				                                      vars: [[28], [29], [40], [41]]
 				                                      cons: [
-				                                        Foreign: Main.Cons:I32 -> Main.IntList -> Main.IntList = [18],
-				                                        [18] = [19] -> [30] -> [31],
+				                                        Foreign: Main.Cons:I32 -> Main.IntList -> Main.IntList = [28],
+				                                        [28] = [29] -> [40] -> [41],
 				                                        Exists:
-				                                          vars: [[20], [21], [29]]
+				                                          vars: [[30], [31], [39]]
 				                                          cons: [
-				                                            Local: Main.car = [20],
-				                                            [20] = [21] -> [29],
+				                                            Local: Main.car = [30],
+				                                            [30] = [31] -> [39],
 				                                            Exists:
-				                                              vars: [[22], [23], [28]]
+				                                              vars: [[32], [33], [38]]
 				                                              cons: [
-				                                                Local: Main.rectest.id = [22],
-				                                                [22] = [23] -> [28],
+				                                                Local: Main.rectest.id = [32],
+				                                                [32] = [33] -> [38],
 				                                                Exists:
-				                                                  vars: [[24], [25], [26], [27]]
+				                                                  vars: [[34], [35], [36], [37]]
 				                                                  cons: [
-				                                                    Foreign: Main.Cons:I32 -> Main.IntList -> Main.IntList = [24],
-				                                                    [24] = [25] -> [26] -> [27],
-				                                                    I32 = [25],
-				                                                    Foreign: Main.Nil:Main.IntList = [26],
-				                                                    [27] = [23],
+				                                                    Foreign: Main.Cons:I32 -> Main.IntList -> Main.IntList = [34],
+				                                                    [34] = [35] -> [36] -> [37],
+				                                                    I32 = [35],
+				                                                    Foreign: Main.Nil:Main.IntList = [36],
+				                                                    [37] = [33],
 				                                                  ],
-				                                                [28] = [21],
+				                                                [38] = [31],
 				                                              ],
-				                                            [29] = [19],
+				                                            [39] = [29],
 				                                          ],
-				                                        Foreign: Main.Nil:Main.IntList = [30],
-				                                        [31] = [17],
+				                                        Foreign: Main.Nil:Main.IntList = [40],
+				                                        [41] = [27],
 				                                      ],
-				                                    [32] = [11],
+				                                    [42] = [21],
 				                                  ],
 				                              ]
 				                              genTargets: [],
 				                          ]
 				                          bodyCons:[
-				                            [11] = [8],
+				                            [21] = [16],
 				                          ],
 				                      ]
 				                      genTargets: [Main.rectest.res],
 				                  ]
 				                  bodyCons:[
-				                    Local: Main.rectest.res = [6],
+				                    Exists:
+				                      vars: [[13], [14]]
+				                      cons: [
+				                        Local: Main.rectest.res = [13],
+				                        [13] = [14],
+				                        [14] = [12],
+				                      ],
 				                  ],
 				              ]
 				              genTargets: [],
 				          ]
 				          bodyCons:[
-				            [6] = [1],
+				            [12] = [1],
 				          ],
 				      ]
 				      genTargets: [Main.rectest],
@@ -562,20 +616,26 @@ public class ConstrainerTest {
 				      cons: [
 				        Let:
 				          rigids: []
-				          flexes: [[32], [33], [34]]
+				          flexes: [[34], [35], [36]]
 				          header: {
-				            Main.snd_.x: [32],
-				            Main.snd_.y: [33],
+				            Main.snd_.x: [34],
+				            Main.snd_.y: [35],
 				          }
 				          headerCons: [
 				            Phase:
 				              cons: [
-				                Local: Main.snd_.y = [34],
+				                Exists:
+				                  vars: [[37], [38]]
+				                  cons: [
+				                    Local: Main.snd_.y = [37],
+				                    [37] = [38],
+				                    [38] = [36],
+				                  ],
 				              ]
 				              genTargets: [],
 				          ]
 				          bodyCons:[
-				            [32] -> [33] -> [34] = [4],
+				            [34] -> [35] -> [36] = [4],
 				          ],
 				      ]
 				      genTargets: [Main.snd_],
@@ -583,26 +643,26 @@ public class ConstrainerTest {
 				      cons: [
 				        Let:
 				          rigids: []
-				          flexes: [[27], [28]]
+				          flexes: [[29], [30]]
 				          header: {
-				            Main.snd.p: [27],
+				            Main.snd.p: [29],
 				          }
 				          headerCons: [
 				            Phase:
 				              cons: [
 				                Exists:
-				                  vars: [[29], [30], [31]]
+				                  vars: [[31], [32], [33]]
 				                  cons: [
-				                    Local: Main.snd.p = [29],
-				                    [29] = [30] -> [31],
-				                    Local: Main.snd_ = [30],
-				                    [31] = [28],
+				                    Local: Main.snd.p = [31],
+				                    [31] = [32] -> [33],
+				                    Local: Main.snd_ = [32],
+				                    [33] = [30],
 				                  ],
 				              ]
 				              genTargets: [],
 				          ]
 				          bodyCons:[
-				            [27] -> [28] = [3],
+				            [29] -> [30] = [3],
 				          ],
 				      ]
 				      genTargets: [Main.snd],
@@ -610,19 +670,25 @@ public class ConstrainerTest {
 				      cons: [
 				        Let:
 				          rigids: []
-				          flexes: [[35], [36]]
+				          flexes: [[39], [40]]
 				          header: {
-				            Main.id.x: [35],
+				            Main.id.x: [39],
 				          }
 				          headerCons: [
 				            Phase:
 				              cons: [
-				                Local: Main.id.x = [36],
+				                Exists:
+				                  vars: [[41], [42]]
+				                  cons: [
+				                    Local: Main.id.x = [41],
+				                    [41] = [42],
+				                    [42] = [40],
+				                  ],
 				              ]
 				              genTargets: [],
 				          ]
 				          bodyCons:[
-				            [35] -> [36] = [5],
+				            [39] -> [40] = [5],
 				          ],
 				      ]
 				      genTargets: [Main.id],
@@ -630,25 +696,25 @@ public class ConstrainerTest {
 				      cons: [
 				        Let:
 				          rigids: []
-				          flexes: [[37]]
+				          flexes: [[43]]
 				          header: {}
 				          headerCons: [
 				            Phase:
 				              cons: [
 				                Exists:
-				                  vars: [[38], [39], [40], [41]]
+				                  vars: [[44], [45], [46], [47]]
 				                  cons: [
-				                    Local: Main.pair = [38],
-				                    [38] = [39] -> [40] -> [41],
-				                    Local: Main.id = [39],
-				                    Local: Main.id = [40],
-				                    [41] = [37],
+				                    Local: Main.pair = [44],
+				                    [44] = [45] -> [46] -> [47],
+				                    Local: Main.id = [45],
+				                    Local: Main.id = [46],
+				                    [47] = [43],
 				                  ],
 				              ]
 				              genTargets: [],
 				          ]
 				          bodyCons:[
-				            [37] = [6],
+				            [43] = [6],
 				          ],
 				      ]
 				      genTargets: [Main.p],
@@ -656,24 +722,24 @@ public class ConstrainerTest {
 				      cons: [
 				        Let:
 				          rigids: []
-				          flexes: [[46]]
+				          flexes: [[52]]
 				          header: {}
 				          headerCons: [
 				            Phase:
 				              cons: [
 				                Exists:
-				                  vars: [[47], [48], [49]]
+				                  vars: [[53], [54], [55]]
 				                  cons: [
-				                    Local: Main.snd = [47],
-				                    [47] = [48] -> [49],
-				                    Local: Main.p = [48],
-				                    [49] = [46],
+				                    Local: Main.snd = [53],
+				                    [53] = [54] -> [55],
+				                    Local: Main.p = [54],
+				                    [55] = [52],
 				                  ],
 				              ]
 				              genTargets: [],
 				          ]
 				          bodyCons:[
-				            [46] = [8],
+				            [52] = [8],
 				          ],
 				      ]
 				      genTargets: [Main.v],
@@ -681,24 +747,24 @@ public class ConstrainerTest {
 				      cons: [
 				        Let:
 				          rigids: []
-				          flexes: [[54]]
+				          flexes: [[60]]
 				          header: {}
 				          headerCons: [
 				            Phase:
 				              cons: [
 				                Exists:
-				                  vars: [[55], [56], [57]]
+				                  vars: [[61], [62], [63]]
 				                  cons: [
-				                    Local: Main.v = [55],
-				                    [55] = [56] -> [57],
-				                    Foreign: Basic.True:Bool = [56],
-				                    [57] = [54],
+				                    Local: Main.v = [61],
+				                    [61] = [62] -> [63],
+				                    Foreign: Basic.True:Bool = [62],
+				                    [63] = [60],
 				                  ],
 				              ]
 				              genTargets: [],
 				          ]
 				          bodyCons:[
-				            [54] = [10],
+				            [60] = [10],
 				          ],
 				      ]
 				      genTargets: [Main.r2],
@@ -714,7 +780,13 @@ public class ConstrainerTest {
 				          headerCons: [
 				            Phase:
 				              cons: [
-				                Local: Main.fst_.x = [26],
+				                Exists:
+				                  vars: [[27], [28]]
+				                  cons: [
+				                    Local: Main.fst_.x = [27],
+				                    [27] = [28],
+				                    [28] = [26],
+				                  ],
 				              ]
 				              genTargets: [],
 				          ]
@@ -754,24 +826,24 @@ public class ConstrainerTest {
 				      cons: [
 				        Let:
 				          rigids: []
-				          flexes: [[42]]
+				          flexes: [[48]]
 				          header: {}
 				          headerCons: [
 				            Phase:
 				              cons: [
 				                Exists:
-				                  vars: [[43], [44], [45]]
+				                  vars: [[49], [50], [51]]
 				                  cons: [
-				                    Local: Main.fst = [43],
-				                    [43] = [44] -> [45],
-				                    Local: Main.p = [44],
-				                    [45] = [42],
+				                    Local: Main.fst = [49],
+				                    [49] = [50] -> [51],
+				                    Local: Main.p = [50],
+				                    [51] = [48],
 				                  ],
 				              ]
 				              genTargets: [],
 				          ]
 				          bodyCons:[
-				            [42] = [7],
+				            [48] = [7],
 				          ],
 				      ]
 				      genTargets: [Main.u],
@@ -779,24 +851,24 @@ public class ConstrainerTest {
 				      cons: [
 				        Let:
 				          rigids: []
-				          flexes: [[50]]
+				          flexes: [[56]]
 				          header: {}
 				          headerCons: [
 				            Phase:
 				              cons: [
 				                Exists:
-				                  vars: [[51], [52], [53]]
+				                  vars: [[57], [58], [59]]
 				                  cons: [
-				                    Local: Main.u = [51],
-				                    [51] = [52] -> [53],
-				                    I32 = [52],
-				                    [53] = [50],
+				                    Local: Main.u = [57],
+				                    [57] = [58] -> [59],
+				                    I32 = [58],
+				                    [59] = [56],
 				                  ],
 				              ]
 				              genTargets: [],
 				          ]
 				          bodyCons:[
-				            [50] = [9],
+				            [56] = [9],
 				          ],
 				      ]
 				      genTargets: [Main.r1],

--- a/src/test/java/zlk/FeatureTest.java
+++ b/src/test/java/zlk/FeatureTest.java
@@ -54,8 +54,8 @@ public class FeatureTest {
 
 		sum list =
 		  case list of
-		    | Nil -> 0
-		    | Cons hd tl -> add hd (sum tl)
+		    Nil -> 0
+		    Cons hd tl -> add hd (sum tl)
 
 		ans = sum (Cons 3 (Cons 2 (Cons 1 Nil)))
 		""";
@@ -123,7 +123,7 @@ public class FeatureTest {
 
 		a1 = f1 2
 		a2 = case f2 2 of
-		| Pair_ a b -> add a b
+		  Pair_ a b -> add a b
 		""";
 		var module = new ModuleTester(src, CompileLevel.BYTECODE_GEN);
 		module.getType("f1").is("I32 -> I32");
@@ -172,14 +172,14 @@ public class FeatureTest {
 	void genericTypeInLetExp() {
 		String src ="""
 		type IntList =
-		| Nil
-		| Cons I32 IntList
+		  | Nil
+		  | Cons I32 IntList
 		car list =
 		  case list of
-		  | Nil ->
-		    0
-		  | Cons hd tl ->
-		    hd
+		    Nil ->
+		      0
+		    Cons hd tl ->
+		      hd
 		rectest =
 		  let
 		    id x =

--- a/src/test/java/zlk/ReconTest.java
+++ b/src/test/java/zlk/ReconTest.java
@@ -49,15 +49,15 @@ public class ReconTest {
 	void genericTypeInLetExp() {
 		String src ="""
 				type IntList =
-				| Nil
-				| Cons I32 IntList
+				  | Nil
+				  | Cons I32 IntList
 
 				car list =
 				  case list of
-				  | Nil ->
-				    0
-				  | Cons hd tl ->
-				    hd
+				    Nil ->
+				      0
+				    Cons hd tl ->
+				      hd
 
 				rectest =
 				  let
@@ -117,8 +117,8 @@ public class ReconTest {
 	void userDefinedGenericDatatype() {
 		String src ="""
 				type List a =
-				| Nil
-				| Cons a (List a)
+				  | Nil
+				  | Cons a (List a)
 
 				type Pair a b = Pair_ a b
 

--- a/src/test/java/zlk/tester/ModuleTester.java
+++ b/src/test/java/zlk/tester/ModuleTester.java
@@ -24,8 +24,7 @@ import zlk.common.id.IdMap;
 import zlk.core.Builtin;
 import zlk.idcalc.IcModule;
 import zlk.nameeval.NameEvaluator;
-import zlk.parser.Lexer;
-import zlk.parser.Parser;
+import zlk.parser.Tokenized;
 import zlk.recon.ConstraintExtractor;
 import zlk.recon.FreshFlex;
 import zlk.recon.TypeError;
@@ -50,6 +49,7 @@ public class ModuleTester {
 	}
 
 	private static final String TARGET_MODULE_NAME = "Main";
+	private static final String TARGET_FILE_NAME = "Main.zlk";
 	private final CompileLevel compileLevel;
 	private final String src;
 	private final InMemoryClassLoader classLoader;
@@ -67,7 +67,9 @@ public class ModuleTester {
 		this.src = "module " + TARGET_MODULE_NAME + "\n" + src;  // TODO: これ要る？
 		this.classLoader = new InMemoryClassLoader();
 
-		this.ast = new Parser(new Lexer(TARGET_MODULE_NAME + ".zlk", this.src)).parse();
+		Tokenized tokens = new zlk.parser.Lexer(TARGET_FILE_NAME, this.src).lex();
+		this.ast = zlk.parser.Parser.parse(tokens);
+
 		if(this.compileLevel == CompileLevel.PARSE) {
 			return;
 		}
@@ -103,7 +105,7 @@ public class ModuleTester {
 
 		record NameAndBytecode(String name, byte[] bytecode) {}
 		List<NameAndBytecode> classes = new ArrayList<>();
-		new BytecodeGenerator(clconv, types, Builtin.functions()).compile((name, bytecode) -> classes.add(new NameAndBytecode(name, bytecode)));
+		new BytecodeGenerator(clconv, types, Builtin.functions(), TARGET_FILE_NAME).compile((name, bytecode) -> classes.add(new NameAndBytecode(name, bytecode)));
 		classes.forEach(clz -> {
 			DumpOnFailureWatcher.setLastClassDump(clz.name, clz.bytecode);  // TODO: 並列化のためにBeforeEachCallbackでStoreにする
 			addClass(clz.name, clz.bytecode);

--- a/src/test/java/zlk/tester/TypeTester.java
+++ b/src/test/java/zlk/tester/TypeTester.java
@@ -11,7 +11,6 @@ import zlk.common.Type.CtorApp;
 import zlk.common.Type.Var;
 import zlk.common.id.Id;
 import zlk.common.id.IdMap;
-import zlk.parser.Lexer;
 import zlk.parser.Parser;
 
 public final class TypeTester {
@@ -27,7 +26,7 @@ public final class TypeTester {
 	}
 
 	public void is(String expected) {
-		Type expectedTy = simpleEval(new Parser(new Lexer("TypeTester", expected)).parseType());
+		Type expectedTy = simpleEval(Parser.parseTypeForTest(expected));
 		expectedTy = importFromModule(expectedTy);
 		is(expectedTy);
 	}


### PR DESCRIPTION
close #13 

## 変更点
- パーサをインデントを記述可能にしたPEGに
- オフサイドルールを復活
  - 柔軟に記述できるためオフサイドの有無も含めた複数の記法に対応

## 残件
- インデントを利用したエラー回復