### PR TITLE
追加 パターンマッチの網羅性検査

### DIFF
--- a/src/main/java/zlk/bytecodegen/BytecodeGenerator.java
+++ b/src/main/java/zlk/bytecodegen/BytecodeGenerator.java
@@ -85,9 +85,9 @@ public final class BytecodeGenerator {
 		this.ctors = new IdMap<>();
 		this.pendings = new Stack<>();
 
-		javaClasses.put(Type.UNIT.ctor(), JavaType.VOID);
-		javaClasses.put(Type.BOOL.ctor(), new JavaType.Simple("java/lang/Boolean"));
-		javaClasses.put(Type.I32.ctor(), new JavaType.Simple("java/lang/Integer"));
+		javaClasses.put(Type.UNIT.id(), JavaType.VOID);
+		javaClasses.put(Type.BOOL.id(), new JavaType.Simple("java/lang/Boolean"));
+		javaClasses.put(Type.I32.id(), new JavaType.Simple("java/lang/Integer"));
 	}
 
 	/**
@@ -863,7 +863,7 @@ public final class BytecodeGenerator {
 	private JavaType toJavaType(Type type) {
 
 		return switch(type) {
-		case Type.CtorApp atom -> javaClasses.get(atom.ctor());
+		case Type.CtorApp atom -> javaClasses.get(atom.id());
 		case Type.Arrow _ -> JavaType.FUNCTION;
 		case Type.Var _ -> JavaType.OBJECT;
 		};

--- a/src/main/java/zlk/common/Type.java
+++ b/src/main/java/zlk/common/Type.java
@@ -26,10 +26,10 @@ permits CtorApp, Arrow, Var {
 
 	/**
 	 * 関数型以外の型
-	 * @param ctor 型構築子
+	 * @param id 型構築子
 	 * @param args 型パラメータ
 	 */
-	record CtorApp(Id ctor, Seq<Type> args) implements Type {
+	record CtorApp(Id id, Seq<Type> args) implements Type {
 		public CtorApp(Id id) {
 			this(id, Seq.of());
 		}

--- a/src/main/java/zlk/core/Builtin.java
+++ b/src/main/java/zlk/core/Builtin.java
@@ -17,9 +17,8 @@ public record Builtin(
 		Id id,
 		Type type,
 		Instructions insn)
-implements Instructions
-{
-	public static Seq<Builtin> functions(){
+implements Instructions {
+	public static Seq<Builtin> functions() {
 		Type i32i32i32 = Type.arrow(I32, I32, I32);
 		Type i32bool = Type.arrow(I32, BOOL);
 

--- a/src/main/java/zlk/nameeval/NameEvaluator.java
+++ b/src/main/java/zlk/nameeval/NameEvaluator.java
@@ -57,10 +57,14 @@ public final class NameEvaluator {
 		this.types = new IdMap<>();
 		this.ctors = new IdMap<>();
 
+		// TODO: 組込みのBasic.Boolを作るまでの暫定対応
+		ctors.put(Id.intern("Basic.True"), Type.BOOL);
+		ctors.put(Id.intern("Basic.False"), Type.BOOL);
+
 		env = new Env();
 		Type.BUILTIN.forEach(ty -> {
 			try {
-				types.put(env.registerGlobal(ty.ctor()), ty);
+				types.put(env.registerGlobal(ty.id()), ty);
 			} catch (DuplicatedNameException e) {
 				throw new Error("builtin type dupicated", e);
 			}

--- a/src/main/java/zlk/parser/Parser.java
+++ b/src/main/java/zlk/parser/Parser.java
@@ -270,14 +270,16 @@ public final class Parser {
 	/* パターン
 	 * <aPattern>   ::= _
 	 *                | <lcid>
+	 *                | <ctorHead>
 	 *                | ( <pattern> )
 	 *
-	 * <pattern>    ::= <ctorHead> <aPattern>*
+	 * <pattern>    ::= <ctorHead> <aPattern>+
 	 *                | <aPattern>
 	 */
 	static final Peg<Pattern> aPattern = choice(
 			WILDCARD.map(t -> new Pattern.Wildcard(t.loc())),
 			LCID.map(t -> new Pattern.Var(t.str(), t.loc())),
+			ctorHead.map(t -> new Pattern.Ctor(t.str(), Seq.of(), t.loc())),
 			sequence(LPAREN, lazy(() -> pattern()), RPAREN,
 					(s, pat, e) -> pat.updateLoc(locRange(s, e))));
 
@@ -292,8 +294,6 @@ public final class Parser {
 
 	/* 式
 	 * <literal>    ::= <digits>
-	 *                | True
-	 *                | False
 	 *
 	 * <aExp>       ::= <literal>
 	 *                | <lcid>
@@ -319,10 +319,8 @@ public final class Parser {
 	 */
 	static final Peg<Exp> exp_ = lazy(() -> exp());
 
-	static final Peg<Exp.Cnst> literal = choice(
-			DIGITS.map(t -> new Exp.Cnst(Integer.parseInt(t.str()), t.loc())),
-			TRUE.map(t -> new Exp.Cnst(true, t.loc())),
-			FALSE.map(t -> new Exp.Cnst(false, t.loc())));
+	static final Peg<Exp.Cnst> literal =
+			DIGITS.map(t -> new Exp.Cnst(Integer.parseInt(t.str()), t.loc()));
 
 	static final Peg<Exp> aExp = choice(
 			literal,

--- a/src/main/java/zlk/patterncheck/PatternChecker.java
+++ b/src/main/java/zlk/patterncheck/PatternChecker.java
@@ -1,0 +1,319 @@
+package zlk.patterncheck;
+
+import java.util.Optional;
+
+import zlk.common.Location;
+import zlk.common.Type;
+import zlk.common.id.Id;
+import zlk.common.id.IdMap;
+import zlk.idcalc.IcCaseBranch;
+import zlk.idcalc.IcExp;
+import zlk.idcalc.IcModule;
+import zlk.idcalc.IcPattern;
+import zlk.idcalc.IcPattern.Arg;
+import zlk.util.collection.Seq;
+import zlk.util.collection.SeqBuffer;
+
+// http://moscova.inria.fr/~maranget/papers/warn/warn.pdf
+
+public final class PatternChecker {
+	public static Seq<PcError> check(IcModule module, IdMap<Type> types) {
+		PatternChecker checker = new PatternChecker(module, types);
+		module.decls().forEach(decl -> {
+			decl.body().walk(exp -> {
+				if(exp instanceof IcExp.IcCase caseExp) {
+					checker.check(caseExp);
+				}
+			});
+		});
+		return checker.errors.toSeq();
+	}
+
+	private final IcModule module;
+	private final IdMap<UnionInfo> unionInfos;
+	private final IdMap<Type> types;
+	private final IdMap<Id> ctorToUnion;
+	private final SeqBuffer<PcError> errors;
+	private PatternChecker(IcModule module, IdMap<Type> types) {
+		this.module = module;
+		this.types = types;
+		this.errors = new SeqBuffer<>();
+
+		this.unionInfos = new IdMap<>();
+		this.ctorToUnion = new IdMap<>();
+		// 組込み
+		Id boolId = Type.BOOL.id();
+		UnionInfo boolInfo = new UnionInfo(
+				boolId,
+				Seq.of(
+						new CtorInfo(boolId, Id.intern("Basic.False"), 0),
+						new CtorInfo(boolId, Id.intern("Basic.True"), 0)));
+		unionInfos.put(boolId, boolInfo);
+		boolInfo.ctors.forEach(ctor -> ctorToUnion.put(ctor.id, boolId));
+		// コード
+		module.types().forEach(tyDecl -> {
+			Id unionId = tyDecl.id();
+			Seq<CtorInfo> ctors = tyDecl.ctors()
+					.map(ctor -> new CtorInfo(unionId, ctor.id(), ctor.args().size()));
+			unionInfos.put(unionId, new UnionInfo(unionId, ctors));
+			ctors.forEach(ctor -> ctorToUnion.put(ctor.id(), unionId));
+		});
+	}
+
+	private record CtorInfo(
+			Id unionId,
+			Id id,
+			int arity
+	) {}
+
+	private record UnionInfo(
+			Id id,
+			Seq<CtorInfo> ctors
+	) {}
+
+
+	/**
+	 * ケース式のパターンの冗長性と網羅性を検査しエラーに記録する
+	 * @param exp ケース式
+	 */
+	private void check(IcExp.IcCase exp) {
+		Seq<IcPattern> patterns = exp.branches().map(IcCaseBranch::pattern);
+		Location overallLoc = exp.loc();
+		SeqBuffer<Seq<PcPattern>> usefulRows = new SeqBuffer<>();
+
+
+		// 冗長パターンチェック
+		patterns.forEachIndexed((caseIdx, pat) -> {
+			Seq<PcPattern> row = Seq.of(toPcPattern(pat));
+
+			// 上の行まで完全に覆われている行は冗長
+			if(findWitness(row, usefulRows).isEmpty()) {
+				errors.add(new PcError.Redundant(overallLoc, pat.loc(), caseIdx));
+			} else {
+				usefulRows.add(row);
+			}
+		});
+
+		// 網羅チェック
+		findWitness(anythings(1), usefulRows).ifPresent(missing -> {
+			errors.add(new PcError.Incomplete(overallLoc, missing));
+		});
+	}
+
+	private PcPattern toPcPattern(IcPattern pattern) {
+		return switch(pattern) {
+		case IcPattern.Wildcard(Location _) -> PcPattern.Anything.SINGLETON;
+		case IcPattern.Var(Id _, Location _) -> PcPattern.Anything.SINGLETON;
+		case IcPattern.Dector(IcExp.IcVarCtor ctor, Seq<Arg> args, Location _) -> {
+			Id ctorId = ctor.id();
+			Id unionId = ctorToUnion.get(ctorId);
+			yield new PcPattern.Ctor(unionId, ctorId, args.map(arg -> toPcPattern(arg.pattern())));
+		}
+		};
+	}
+
+	/**
+	 * {@code vector}に含まれるが{@code matrix}に含まれないwitnessがあれば返す
+	 * @param vector
+	 * @param matrix
+	 * @return
+	 */
+	private Optional<Seq<PcPattern>> findWitness(
+			Seq<PcPattern> vector,
+			SeqBuffer<Seq<PcPattern>> matrix
+	) {
+		if (matrix.isEmpty()) {
+			return Optional.of(vector);
+		}
+
+		if (vector.isEmpty()) {
+			return Optional.empty();
+		}
+
+		return switch (vector.head()) {
+		case PcPattern.Anything _ -> findWitnessForAnything(vector.tail(), matrix);
+
+		case PcPattern.Ctor ctor -> {
+			SeqBuffer<Seq<PcPattern>> specializedMatrix = specializeByCtor(matrix, ctor);
+
+			Seq<PcPattern> specializedVector = Seq.concat(ctor.args(), vector.tail());
+
+			yield findWitness(specializedVector, specializedMatrix)
+					.map(witness -> recoverCtor(ctor, witness));
+		}
+
+		// TODO: リテラル
+		// case SimplePattern.Literal lit -> {
+		// List<List<SimplePattern>> specializedMatrix =
+		// specializeByLiteral(matrix, lit.value());
+		// yield findWitness(specializedMatrix, tail)
+		// .map(witness -> prepend(lit, witness));
+		// }
+		};
+	}
+
+	private Optional<Seq<PcPattern>> findWitnessForAnything(
+			Seq<PcPattern> tail,
+			SeqBuffer<Seq<PcPattern>> matrix
+		) {
+		Seq<PcPattern.Ctor> seenCtors = seenConstructors(matrix);
+
+		if (seenCtors.isEmpty()) {
+			return findWitness(tail, specializeByDefault(matrix))
+					.map(witness -> Seq.concat(anythings(1), witness));
+		}
+
+		UnionInfo unionInfo = unionInfos.get(seenCtors.head().unionId());
+
+		// 念のため同じunionであることを確認
+		Id unionId = unionInfo.id();
+		seenCtors.findFirst(ctor -> ctor.unionId() != unionId).ifPresent(ctor -> {
+			throw new IllegalStateException(
+					"constructors from different unions appear in the same pattern column: "
+							+ unionId + " and " + ctor.unionId());
+		});
+
+		// 出現していないCtorがあるとき
+		if (seenCtors.size() < unionInfo.ctors().size()) {
+			// AnythingでCtorが吸収されているかも
+			Optional<Seq<PcPattern>> tailWitness = findWitness(tail, specializeByDefault(matrix));
+			if (tailWitness.isEmpty()) {
+				return Optional.empty();
+			}
+
+			Seq<Id> seenCtorIds = seenCtors.map(ctor -> ctor.ctorId());
+			CtorInfo missingCtor = unionInfo.ctors()
+					.findFirst(ctor -> !seenCtorIds.contains(ctor.id()))
+					.get();
+
+			return Optional.of(prepend(
+					new PcPattern.Ctor(
+							missingCtor.unionId(),
+							missingCtor.id(),
+							anythings(missingCtor.arity())),
+					tailWitness.get()));
+		}
+
+		// 全Ctorが出現済み
+		for (CtorInfo ctor : unionInfo.ctors()) {
+			SeqBuffer<Seq<PcPattern>> specializedMatrix = specializeByCtor(matrix, ctor);
+
+			Seq<PcPattern> specializedVector = Seq.concat(anythings(ctor.arity()), tail);
+
+			Optional<Seq<PcPattern>> witness = findWitness(specializedVector, specializedMatrix);
+
+			if (witness.isPresent()) {
+				return Optional.of(recoverCtor(ctor, witness.get()));
+			}
+		}
+		return Optional.empty();
+	}
+
+	private static SeqBuffer<Seq<PcPattern>> specializeByCtor(
+			SeqBuffer<Seq<PcPattern>> matrix,
+			CtorInfo ctor
+	) {
+		SeqBuffer<Seq<PcPattern>> result = new SeqBuffer<>();
+
+		for (Seq<PcPattern> row : matrix) {
+			Optional<Seq<PcPattern>> specialized = specializeRowByCtor(row, ctor);
+			specialized.ifPresent(result::add);
+		}
+
+		return result;
+	}
+	private static SeqBuffer<Seq<PcPattern>> specializeByCtor(
+			SeqBuffer<Seq<PcPattern>> matrix,
+			PcPattern.Ctor ctor
+	) {
+		return specializeByCtor(matrix, new CtorInfo(ctor.unionId(), ctor.ctorId(), ctor.args().size()));
+	}
+
+	private static Optional<Seq<PcPattern>> specializeRowByCtor(Seq<PcPattern> row, CtorInfo ctor) {
+		if (row.isEmpty()) {
+			throw new IllegalStateException("cannot specialize an empty row");
+		}
+
+		return switch (row.head()) {
+
+		case PcPattern.Anything _ -> Optional.of(Seq.concat(anythings(ctor.arity()), row.tail()));
+
+		case PcPattern.Ctor(Id _, Id ctorId, Seq<PcPattern> args) -> {
+			if (ctor.id() == ctorId) {
+				yield Optional.of(Seq.concat(args, row.tail()));
+			} else {
+				yield Optional.empty();
+			}
+		}
+
+		// TODO: リテラル
+		// コンストラクタとリテラルは同位置に出現しないためエラー
+		};
+	}
+
+	private static SeqBuffer<Seq<PcPattern>> specializeByDefault(SeqBuffer<Seq<PcPattern>> matrix) {
+		SeqBuffer<Seq<PcPattern>> result = new SeqBuffer<>();
+
+		for (Seq<PcPattern> row : matrix) {
+			Optional<Seq<PcPattern>> specialized = specializeRowByDefault(row);
+			specialized.ifPresent(result::add);
+		}
+
+		return result;
+	}
+
+	private static Optional<Seq<PcPattern>> specializeRowByDefault(Seq<PcPattern> row) {
+		if (row.isEmpty()) {
+			return Optional.empty();
+		}
+
+		return switch (row.head()) {
+		case PcPattern.Anything _ -> Optional.of(row.tail());
+		case PcPattern.Ctor _ -> Optional.empty();
+
+		// TODO: リテラル
+		// コンストラクタと同様にデフォルトはない
+		};
+	}
+
+	private static Seq<PcPattern.Ctor> seenConstructors(SeqBuffer<Seq<PcPattern>> matrix) {
+		SeqBuffer<PcPattern.Ctor> result = new SeqBuffer<>();
+
+		matrix.forEach(row -> {
+			if(!row.isEmpty() && row.head() instanceof PcPattern.Ctor ctor) {
+				result.add(ctor);
+			}
+		});
+
+		return result.toSeq();
+	}
+
+	private static Seq<PcPattern> recoverCtor(CtorInfo ctor, Seq<PcPattern> specializedWitness) {
+		if (specializedWitness.size() < ctor.arity()) {
+			throw new IllegalStateException("witness is shorter than constructor arity");
+		}
+
+		Seq<PcPattern> args = specializedWitness.take(ctor.arity());
+		Seq<PcPattern> rest = specializedWitness.drop(ctor.arity());
+
+		return prepend(new PcPattern.Ctor(ctor.unionId(), ctor.id(), args), rest);
+	}
+	private static Seq<PcPattern> recoverCtor(
+			PcPattern.Ctor ctor,
+			Seq<PcPattern> specializedWitness
+	) {
+		return recoverCtor(new CtorInfo(ctor.unionId(), ctor.ctorId(), ctor.args().size()), specializedWitness);
+	}
+
+	private static Seq<PcPattern> anythings(int size) {
+		return Seq.repeat(PcPattern.Anything.SINGLETON, size);
+	}
+
+	// 特に速くはないが読み易さのため
+	private static <E> Seq<E> prepend(E head, Seq<E> tail) {
+		SeqBuffer<E> result = new SeqBuffer<>(tail.size() + 1);
+		result.add(head);
+		result.addAll(tail);
+		return result.toSeq();
+	}
+}

--- a/src/main/java/zlk/patterncheck/PcError.java
+++ b/src/main/java/zlk/patterncheck/PcError.java
@@ -1,0 +1,17 @@
+package zlk.patterncheck;
+
+import zlk.common.Location;
+import zlk.util.collection.Seq;
+
+public sealed interface PcError {
+	record Incomplete(
+			Location location,
+			Seq<PcPattern> examples
+	) implements PcError {}
+
+	record Redundant(
+			Location overallLocation,
+			Location patternLocation,
+			int caseIndex
+	) implements PcError {}
+}

--- a/src/main/java/zlk/patterncheck/PcPattern.java
+++ b/src/main/java/zlk/patterncheck/PcPattern.java
@@ -1,0 +1,21 @@
+package zlk.patterncheck;
+
+import zlk.common.id.Id;
+import zlk.util.collection.Seq;
+
+public sealed interface PcPattern {
+	enum Anything implements PcPattern {
+		SINGLETON;
+
+		@Override
+		public String toString() {
+			return "Anything";
+		}
+	}
+//	record Literal(Object value) implements PcPattern {}
+	record Ctor(
+			Id unionId,
+			Id ctorId,
+			Seq<PcPattern> args
+	) implements PcPattern {}
+}

--- a/src/main/java/zlk/recon/FlatType.java
+++ b/src/main/java/zlk/recon/FlatType.java
@@ -29,10 +29,10 @@ permits CtorApp1, Fun1 {
 	default Type toType() {
 		return switch(this) {
 		case CtorApp1(Id id, Seq<Variable> args) -> {
-			if(id.equals(Type.BOOL.ctor())) {
+			if(id.equals(Type.BOOL.id())) {
 				yield Type.BOOL;
 			}
-			if(id.equals(Type.I32.ctor())) {
+			if(id.equals(Type.I32.id())) {
 				yield Type.I32;
 			}
 			// TODO: user defined type

--- a/src/main/java/zlk/recon/constraint/RcType.java
+++ b/src/main/java/zlk/recon/constraint/RcType.java
@@ -23,8 +23,8 @@ permits VarN, AppN, FunN {
 	record AppN(Id id, Seq<RcType> args) implements RcType {}
 	record FunN(RcType arg, RcType ret) implements RcType {}
 
-	public static final RcType BOOL = new AppN(Type.BOOL.ctor(), Seq.of());
-	public static final RcType I32  = new AppN(Type.I32.ctor() , Seq.of());
+	public static final RcType BOOL = new AppN(Type.BOOL.id(), Seq.of());
+	public static final RcType I32  = new AppN(Type.I32.id() , Seq.of());
 
 	/**
 	 * 注釈用の型から生成された制約用の型情報

--- a/src/main/java/zlk/util/collection/Seq.java
+++ b/src/main/java/zlk/util/collection/Seq.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -74,6 +75,27 @@ public sealed interface Seq<E> extends Iterable<E> {
 		for(int i = 0; i < size; i++) {
 			data[i] = itr.next();
 		}
+		return new ArraySeq<>(data);
+	}
+
+	public static <E> Seq<E> repeat(E element, int count) {
+		if(count < 0) {
+			throw new IllegalArgumentException("count: "+count);
+		}
+		switch(count) {
+		case 0:
+			return Seq.of();
+		case 1:
+			return Seq.of(element);
+		case 2:
+			return new ArraySeq<>(new Object[] {element, element});
+		case 3:
+			return new ArraySeq<>(new Object[] {element, element, element});
+		case 4:
+			return new ArraySeq<>(new Object[] {element, element, element, element});
+		}
+		Object[] data = new Object[count];
+		Arrays.fill(data, element);
 		return new ArraySeq<>(data);
 	}
 
@@ -232,11 +254,19 @@ public sealed interface Seq<E> extends Iterable<E> {
 				IntArraySeq::new);
 	}
 
-	// TODO: 虚無のaccumulatorを入れた以下のdefault実装は充分に最適化されないかもしれない
+	// TODO: 要計測 抽象化しすぎて最適化されないかもしれない
 	default Seq<E> filter(Predicate<? super E> predicate) {
 		return fold(
 				(e, stack) -> { if(predicate.test(e) ) { stack.add(e); } return stack; },
 				new SeqBuffer<E>(size()),
+				SeqBuffer::toSeq);
+	}
+
+	// TODO: 要計測 抽象化しすぎて最適化されないかもしれない
+	default <R> Seq<R> filterMap(Function<? super E, Optional<? extends R>> mapper) {
+		return fold(
+				(e, stack) -> { mapper.apply(e).ifPresent(r -> stack.add(r)); return stack; },
+				new SeqBuffer<R>(size()),
 				SeqBuffer::toSeq);
 	}
 
@@ -285,16 +315,24 @@ public sealed interface Seq<E> extends Iterable<E> {
 		return sb.toString();
 	}
 
-	default boolean anyMatch(Predicate<? super E> predicate) {
+	default Optional<E> findFirst(Predicate<? super E> predicate) {
 		if(isEmpty()) {
-			return false;
+			return Optional.empty();
 		}
 		for(E e : this) {
 			if(predicate.test(e)) {
-				return true;
+				return Optional.of(e);
 			}
 		}
-		return false;
+		return Optional.empty();
+	}
+
+	default boolean anyMatch(Predicate<? super E> predicate) {
+		return findFirst(predicate).isPresent();
+	}
+
+	default boolean allMatch(Predicate<? super E> predicate) {
+		return findFirst(predicate.negate()).isEmpty();
 	}
 
 	/**
@@ -371,6 +409,11 @@ final class EmptySeq<E> implements Seq<E> {
 			return equals(other);
 		}
 		return false;
+	}
+
+	@Override
+	public String toString() {
+		return "[]";
 	}
 }
 
@@ -458,6 +501,11 @@ final class SingletonSeq<E> implements Seq<E> {
 			return equals(other);
 		}
 		return false;
+	}
+
+	@Override
+	public String toString() {
+		return "[" + element + "]";
 	}
 }
 
@@ -558,6 +606,11 @@ final class ArraySeq<E> implements Seq<E> {
 			return equals(other);
 		}
 		return false;
+	}
+
+	@Override
+	public String toString() {
+		return "[" + join(", ") + "]";
 	}
 }
 
@@ -663,6 +716,11 @@ final class SliceSeq<E> implements Seq<E> {
 		}
 		return false;
 	}
+
+	@Override
+	public String toString() {
+		return "[" + join(", ") + "]";
+	}
 }
 
 final class ReversedSeq<E> implements Seq<E> {
@@ -766,6 +824,11 @@ final class ReversedSeq<E> implements Seq<E> {
 			return equals(other);
 		}
 		return false;
+	}
+
+	@Override
+	public String toString() {
+		return "[" + join(", ") + "]";
 	}
 }
 

--- a/src/test/java/zlk/PatternMatchTest.java
+++ b/src/test/java/zlk/PatternMatchTest.java
@@ -1,0 +1,196 @@
+package zlk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import zlk.common.id.Id;
+import zlk.patterncheck.PcError;
+import zlk.patterncheck.PcError.Incomplete;
+import zlk.patterncheck.PcPattern;
+import zlk.tester.ModuleTester;
+import zlk.tester.ModuleTester.CompileLevel;
+import zlk.util.collection.Seq;
+
+public class PatternMatchTest {
+	@Test
+	void exhaustiveBoolCaseHasNoError() {
+		String src = """
+		toInt b =
+		  case b of
+		    False -> 0
+		    True -> 1
+		""";
+
+		var module = new ModuleTester(src, CompileLevel.PATTERN_CHECK);
+		Seq<PcError> errors = module.getPcErrors();
+
+		assertNoErrors(errors);
+	}
+
+	@Test
+	void incompleteBoolCaseReportsMissingConstructor() {
+		String src = """
+		toInt b =
+		  case b of
+		    True -> 1
+		""";
+
+		var module = new ModuleTester(src, CompileLevel.PATTERN_CHECK);
+		Seq<PcError> errors = module.getPcErrors();
+
+		assertEquals(1, errors.size());
+		PcError.Incomplete incomplete = (Incomplete) errors.head();
+
+		Seq<PcPattern> witness = incomplete.examples();
+		assertEquals(1, witness.size());
+		assertCtor(witness.head(), "Bool", "Basic.False", 0);
+	}
+
+	@Test
+	void wildcardMakesLaterConstructorBranchRedundant() {
+		String src = """
+		toInt b =
+		  case b of
+		    _ -> 0
+		    True -> 1
+		""";
+
+		var module = new ModuleTester(src, CompileLevel.PATTERN_CHECK);
+		Seq<PcError> errors = module.getPcErrors();
+
+		assertEquals(1, errors.size());
+		assertTrue(errors.head() instanceof PcError.Redundant);
+	}
+
+	@Test
+	void incompleteUserDefinedListCaseReportsSingleConsWitness() {
+		String src = """
+		type List a =
+		  | Nil
+		  | Cons a (List a)
+
+		length xs =
+		  case xs of
+		    Nil -> 0
+		""";
+
+		var module = new ModuleTester(src, CompileLevel.PATTERN_CHECK);
+		Seq<PcError> errors = module.getPcErrors();
+
+		assertEquals(1, errors.size());
+		PcError.Incomplete incomplete = (Incomplete) errors.head();
+
+		Seq<PcPattern> witness = incomplete.examples();
+		assertEquals(1, witness.size());
+		PcPattern.Ctor cons = assertCtor(witness.head(), "Main.List", "Main.Cons", 2);
+		assertTrue(cons.args().at(0) instanceof PcPattern.Anything);
+		assertTrue(cons.args().at(1) instanceof PcPattern.Anything);
+	}
+
+	@Test
+	void nestedListPatternsCanBeExhaustive() {
+		String src = """
+		type List a =
+		  | Nil
+		  | Cons a (List a)
+
+		classify xs =
+		  case xs of
+		    Nil -> 0
+		    Cons _ Nil -> 1
+		    Cons _ (Cons _ rest) -> 2
+		""";
+
+		var module = new ModuleTester(src, CompileLevel.PATTERN_CHECK);
+		Seq<PcError> errors = module.getPcErrors();
+
+		assertNoErrors(errors);
+	}
+
+	@Test
+	void nestedBranchAfterGeneralConsIsRedundant() {
+		String src = """
+		type List a =
+		  | Nil
+		  | Cons a (List a)
+
+		classify xs =
+		  case xs of
+		    Nil -> 0
+		    Cons _ _ -> 1
+		    Cons _ Nil -> 2
+		""";
+
+		var module = new ModuleTester(src, CompileLevel.PATTERN_CHECK);
+		Seq<PcError> errors = module.getPcErrors();
+
+		assertEquals(1, errors.size());
+		assertTrue(errors.head() instanceof PcError.Redundant);
+	}
+
+	@Test
+	void nestedBoolInsideMaybeCanBeExhaustive() {
+		String src = """
+		type Maybe a =
+		  | Nothing
+		  | Just a
+
+		toInt m =
+		  case m of
+		    Nothing -> 0
+		    Just False -> 1
+		    Just True -> 2
+		""";
+
+		var module = new ModuleTester(src, CompileLevel.PATTERN_CHECK);
+		Seq<PcError> errors = module.getPcErrors();
+
+		assertNoErrors(errors);
+	}
+
+	@Test
+	void nestedBoolInsideMaybeReportsMissingNestedConstructor() {
+		String src = """
+		type Maybe a =
+		  | Nothing
+		  | Just a
+
+		toInt m =
+		  case m of
+		    Nothing -> 0
+		    Just True -> 1
+		""";
+
+		var module = new ModuleTester(src, CompileLevel.PATTERN_CHECK);
+		Seq<PcError> errors = module.getPcErrors();
+
+		assertEquals(1, errors.size());
+		PcError.Incomplete incomplete = (Incomplete) errors.head();
+
+		Seq<PcPattern> witness = incomplete.examples();
+		assertEquals(1, witness.size());
+
+		PcPattern.Ctor just = assertCtor(witness.head(), "Main.Maybe", "Main.Just", 1);
+		assertCtor(just.args().head(), "Bool", "Basic.False", 0);
+	}
+
+	private static void assertNoErrors(Seq<PcError> errors) {
+		assertEquals(0, errors.size(), () -> errors.join(System.lineSeparator()));
+	}
+
+	private static PcPattern.Ctor assertCtor(
+			PcPattern pattern,
+			String expectedUnion,
+			String expectedCtor,
+			int expectedArity
+	) {
+		assertTrue(pattern instanceof PcPattern.Ctor, () -> "expected ctor pattern, but got: " + pattern);
+		PcPattern.Ctor ctor = (PcPattern.Ctor) pattern;
+		assertEquals(Id.intern(expectedUnion), ctor.unionId());
+		assertEquals(Id.intern(expectedCtor), ctor.ctorId());
+		assertEquals(expectedArity, ctor.args().size());
+		return ctor;
+	}
+}

--- a/src/test/java/zlk/tester/ModuleTester.java
+++ b/src/test/java/zlk/tester/ModuleTester.java
@@ -26,6 +26,8 @@ import zlk.idcalc.ExpOrPattern;
 import zlk.idcalc.IcModule;
 import zlk.nameeval.NameEvaluator;
 import zlk.parser.Tokenized;
+import zlk.patterncheck.PatternChecker;
+import zlk.patterncheck.PcError;
 import zlk.recon.ConstraintExtractor;
 import zlk.recon.FreshFlex;
 import zlk.recon.TypeError;
@@ -41,6 +43,7 @@ public class ModuleTester {
 		NAME_EVAL,
 		TYPE_CINT,
 		TYPE_RECON,
+		PATTERN_CHECK,
 		CLOSURE_CONV,
 		BYTECODE_GEN,
 		;
@@ -62,6 +65,7 @@ public class ModuleTester {
 	private Constraint cint = null;
 	private IdentityHashMap<ExpOrPattern, Type> callSiteTypes = null;
 	private IdMap<Type> types = null;
+	private Seq<PcError> pcErrors = null;
 	private CcModule clconv = null;
 	private final Map<String, ValueTester> functions = new HashMap<>();
 
@@ -101,6 +105,11 @@ public class ModuleTester {
 			return;
 		}
 
+		this.pcErrors = PatternChecker.check(module, types);
+		if(this.compileLevel == CompileLevel.PATTERN_CHECK) {
+			return;
+		}
+
 		Seq<Id> builtinIds = Builtin.functions().map(b -> b.id());
 		this.clconv = new ClosureConverter(module, types, callSiteTypes, builtinIds).convert();
 		if(this.compileLevel == CompileLevel.CLOSURE_CONV) {
@@ -135,6 +144,10 @@ public class ModuleTester {
 
 	public IcModule getIdcalcModule() {
 		return module;
+	}
+
+	public Seq<PcError> getPcErrors() {
+		return pcErrors;
 	}
 
 	private TypeTester toTypeTester(Type ty) {


### PR DESCRIPTION
## 変更点
- パターンの網羅性と冗長性の検査
- Bool型の組込みまでの暫定措置
- ネストした引数なしコンストラクタパターンのパース
- Seqクラスに便利メソッド